### PR TITLE
Updated lib link to the latest recommended by computor-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ yarn run start
 ```
 
 ## License
-As we use some parts from the 451 Package to our Wallet also apply the Anti-Military License. See https://github.com/computor-tools/qubic-js-tools
+As we use some parts from the 451 Package to our Wallet also apply the Anti-Military License. See https://github.com/computor-tools/qubic-crypto
 Further our Wallet Code is protected by the AGPL-3.0 License. You may use our Source-Code for what you need to do business.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # qubic.li - Wallet
 
-A simple wallet for the QUBIC Network. Find more about QUBIC on https://doc.qubic.world/ or visit us on https://qubic.li.
+A simple wallet for the QUBIC Network. Find more about QUBIC on https://doc.qubic.world/ or visit us on https://qubic.org/.
 To join the QUBIC Community on discord use this link http://discord.gg/2vDMR8m.
 
 ## Local dev
@@ -17,7 +17,7 @@ yarn run start
 ```
 
 ## License
-As we use some parts from the 451 Package to our Wallet also apply the Anti-Military License. See https://github.com/computor-tools/qubic-js
+As we use some parts from the 451 Package to our Wallet also apply the Anti-Military License. See https://github.com/computor-tools/qubic-js-tools
 Further our Wallet Code is protected by the AGPL-3.0 License. You may use our Source-Code for what you need to do business.
 
 ## Installation


### PR DESCRIPTION
I updated some broken links in the README.md file with good ones.

- https://qubic.org/

- https://github.com/computor-tools/qubic-crypto