### PR TITLE
fix: initialize dashboard balance data on first vault import

### DIFF
--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -112,7 +112,10 @@ export class MainComponent implements AfterViewInit {
       });
     });
 
+    // Get current balance value first, then subscribe to updates
+    this.balances = updaterService.currentBalance.getValue();
     this.setDataSource();
+
     updaterService.currentBalance.subscribe(b => {
       this.balances = b;
       this.setDataSource();


### PR DESCRIPTION
When importing a vault file for the first time, the dashboard would show "No data matching the filter" until navigating away and back. This was caused by a race condition where balance data was loaded before the component subscribed to balance updates.

Now the component retrieves existing balance data immediately using getValue() before setting up the subscription, ensuring imported wallet data displays correctly on first load.