### PR TITLE
fix: improve epoch navigation perf and prevent duplicate API calls

### DIFF
--- a/src/app/balance/balance.component.html
+++ b/src/app/balance/balance.component.html
@@ -164,17 +164,16 @@
         </span>
         <span *ngIf="isShowAllTransactions">
             <div *ngIf="isShowAllTransactions" class="epoch">
-                <button *ngIf="status.processedTickIntervalsPerEpoch[0].epoch < currentSelectedEpoch" mat-icon-button
+                <button *ngIf="canNavigateToPreviousEpoch" mat-icon-button
                     (click)="GetTransactionsByTick(currentSelectedEpoch-1)">
                     <mat-icon class="large-icon">keyboard_arrow_left</mat-icon>
                 </button>
-                <button *ngIf="status.processedTickIntervalsPerEpoch[0].epoch >= currentSelectedEpoch"
-                    [disabled]="status.processedTickIntervalsPerEpoch[0].epoch >= currentSelectedEpoch" mat-icon-button>
+                <button *ngIf="!canNavigateToPreviousEpoch"
+                    [disabled]="true" mat-icon-button>
                     <mat-icon class="large-icon"></mat-icon>
                 </button>
                 <span class="label-epoch">{{ t("balanceComponent.epoch") }}</span> {{currentSelectedEpoch}}
-                <button
-                    *ngIf="status.processedTickIntervalsPerEpoch[status.processedTickIntervalsPerEpoch.length-1].epoch > currentSelectedEpoch"
+                <button *ngIf="canNavigateToNextEpoch"
                     mat-icon-button (click)="GetTransactionsByTick(currentSelectedEpoch+1)">
                     <mat-icon class="large-icon">keyboard_arrow_right</mat-icon>
                 </button>

--- a/src/app/balance/balance.component.scss
+++ b/src/app/balance/balance.component.scss
@@ -159,10 +159,12 @@ mat-card {
 
 .epoch {
     font-size: 2.0em;
+    display: flex;
+    align-items: center;
+    gap: 12px;
 
     .label-epoch {
         font-size: 1.0em;
-        padding-left: 18px;
     }
 
     mat-icon {
@@ -171,6 +173,31 @@ mat-card {
 
     .large-icon {
         font-size: xx-large;
+        width: 1em;
+        height: 1em;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 1;
+    }
+
+    button[mat-icon-button] {
+        display: inline-flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        padding: 0 !important;
+
+        .mdc-button__label {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .mat-mdc-button-touch-target {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
     }
 }
 

--- a/src/app/balance/balance.component.ts
+++ b/src/app/balance/balance.component.ts
@@ -108,7 +108,9 @@ export class BalanceComponent implements OnInit {
       if (s) {
         this.status = s;
         this.currentSelectedEpoch = s.processedTickIntervalsPerEpoch[s.processedTickIntervalsPerEpoch.length - 1].epoch;
-        this.GetTransactionsByTick(this.currentSelectedEpoch);
+        // Just initialize the tick range, don't fetch transactions yet
+        // Transactions will be fetched when user switches to "By Epochs" tab
+        this.GetTransactionsByTick(this.currentSelectedEpoch, false);
       }
     }, errorResponse => {
       console.log('errorResponse:', errorResponse);
@@ -124,20 +126,48 @@ export class BalanceComponent implements OnInit {
       this.lastProcessedTick = this.currentTickArchiver.value
     } else if (element === 'element2') {
       this.isShowAllTransactions = true;
+      // Initialize tick range for the current epoch when switching to epochs view
+      if (this.currentSelectedEpoch > 0) {
+        this.GetTransactionsByTick(this.currentSelectedEpoch, false); // Don't fetch transactions yet
+      }
     }
     this.toggleShowAllTransactionsView();
   }
 
 
-  GetTransactionsByTick(epoch: number): void {
+  get firstEpoch(): number | undefined {
+    return this.status?.processedTickIntervalsPerEpoch?.[0]?.epoch;
+  }
+
+  get lastEpoch(): number | undefined {
+    const intervals = this.status?.processedTickIntervalsPerEpoch;
+    if (!intervals || intervals.length === 0) return undefined;
+    return intervals[intervals.length - 1]?.epoch;
+  }
+
+  get canNavigateToPreviousEpoch(): boolean {
+    return this.firstEpoch !== undefined && this.firstEpoch < this.currentSelectedEpoch;
+  }
+
+  get canNavigateToNextEpoch(): boolean {
+    return this.lastEpoch !== undefined && this.lastEpoch > this.currentSelectedEpoch;
+  }
+
+  GetTransactionsByTick(epoch: number, fetchTransactions: boolean = true): void {
     this.status.processedTickIntervalsPerEpoch
       .filter(t => t.epoch === epoch)
       .forEach(e => {
-        this.initialProcessedTick = e.intervals[0].initialProcessedTick;
-        this.lastProcessedTick = e.intervals[0].lastProcessedTick;
-        this.currentSelectedEpoch = e.epoch;
+        // Only set tick range if intervals exist and have data
+        if (e.intervals && e.intervals.length > 0 && e.intervals[0]) {
+          this.initialProcessedTick = e.intervals[0].initialProcessedTick;
+          this.lastProcessedTick = e.intervals[0].lastProcessedTick;
+          this.currentSelectedEpoch = e.epoch;
+        }
       });
-    this.getAllTransactionByPublicId(this.seedFilterFormControl.value);
+    // Only fetch transactions if explicitly requested (e.g., when navigating between epochs)
+    if (fetchTransactions) {
+      this.getAllTransactionByPublicId(this.seedFilterFormControl.value);
+    }
   }
 
 
@@ -151,8 +181,11 @@ export class BalanceComponent implements OnInit {
         const seeds = this.getSeedsWithOnlyWatch();
         if (seeds.length > 0) {
           this.seedFilterFormControl.setValue(seeds[0].publicId);
+          // No need to call getAllTransactionByPublicId here - setValue will trigger valueChanges
+          return;
         }
       }
+      // Only call if we didn't set a new value above (which would trigger valueChanges)
       this.getAllTransactionByPublicId(this.seedFilterFormControl.value);
     }
   }


### PR DESCRIPTION
- When switching to "By Epochs" view, 3 duplicate API requests were made
- Fix for wrong ticks range initialization for the first loaded epoch
- Center epoch navigation arrows
