### PR TITLE
fix: explorer icon color in light theme and centralize explorer URLs

### DIFF
--- a/src/app/assets/assets.component.ts
+++ b/src/app/assets/assets.component.ts
@@ -20,6 +20,7 @@ import { Router } from '@angular/router';
 import { DecimalPipe } from '@angular/common';
 import { ApiLiveService } from '../services/apis/live/api.live.service';
 import { shortenAddress } from '../utils/address.utils';
+import { ExplorerUrlHelper } from '../services/explorer-url.helper';
 
 
 @Component({
@@ -195,8 +196,7 @@ export class AssetsComponent implements OnInit {
   }
 
   openIssuerIdentity(issuerIdentity: string): void {
-    const url = `https://explorer.qubic.org/network/address/${issuerIdentity}`;
-    window.open(url, '_blank');
+    window.open(ExplorerUrlHelper.getAddressUrl(issuerIdentity), '_blank');
   }
 
   getBalanceAfterFees(): number {

--- a/src/app/balance/balance.component.html
+++ b/src/app/balance/balance.component.html
@@ -50,7 +50,7 @@
                                 <qli-transfer-status [transaction]="transaction"></qli-transfer-status>
                                 &nbsp;
                                 <span class="display-publicid disable-area">
-                                    <a [href]="'https://explorer.qubic.org/network/address/' + transaction.sourceId"
+                                    <a [href]="ExplorerUrlHelper.getAddressUrl(transaction.sourceId)"
                                         target="_blank">
                                         {{ getAddressShortDisplayName(transaction.sourceId)}}
                                     </a>
@@ -90,7 +90,7 @@
                                         </div>
                                         <div class="col-value disable-area">
                                             <span class="value"> <a *ngIf="transaction.id.substring(56) !== 'aaaa'"
-                                                    [href]="'https://explorer.qubic.org/network/tx/' + transaction.id"
+                                                    [href]="ExplorerUrlHelper.getTransactionUrl(transaction.id)"
                                                     target="_blank">{{transaction.id}}
                                                 </a>
                                                 <mat-icon class="icon-color-link icon"
@@ -105,7 +105,7 @@
                                         </div>
                                         <div class="col-value disable-area">
                                             <span class="value"> <a
-                                                    [href]="'https://explorer.qubic.org/network/address/' + transaction.sourceId"
+                                                    [href]="ExplorerUrlHelper.getAddressUrl(transaction.sourceId)"
                                                     target="_blank">
                                                     {{getAddressDisplayName(transaction.sourceId)}}
                                                 </a>
@@ -121,7 +121,7 @@
                                         </div>
                                         <div class="col-value disable-area">
                                             <span class="value"> <a
-                                                    [href]="'https://explorer.qubic.org/network/address/' + transaction.destId"
+                                                    [href]="ExplorerUrlHelper.getAddressUrl(transaction.destId)"
                                                     target="_blank">
                                                     {{getAddressDisplayName(transaction.destId)}}
                                                 </a>
@@ -137,7 +137,7 @@
                                         </div>
                                         <div class="col-value disable-area">
                                             <span class="value"> <a
-                                                    [href]="'https://explorer.qubic.org/network/tick/' + transaction.targetTick"
+                                                    [href]="ExplorerUrlHelper.getTickUrl(transaction.targetTick)"
                                                     target="_blank">{{ transaction.targetTick | number: '1.0-0' }}
                                                 </a>
                                             </span>
@@ -214,7 +214,7 @@
                             </span>
                             &nbsp;
                             <span class="display-publicid disable-area">
-                                <a [href]="'https://explorer.qubic.org/network/address/' + transaction.transactions[0].transaction.sourceId"
+                                <a [href]="ExplorerUrlHelper.getAddressUrl(transaction.transactions[0].transaction.sourceId)"
                                     target="_blank">
                                     <!-- Compact name for small screens (when datetime is in header) -->
                                     <span class="address-name-compact">{{ getAddressCompactDisplayName(transaction.transactions[0].transaction.sourceId)}}</span>
@@ -271,7 +271,7 @@
                                     <div class="col-value disable-area">
                                         <span class="value"> <a
                                                 *ngIf="transaction.transactions[0].transaction.txId.substring(56) !== 'aaaa'"
-                                                [href]="'https://explorer.qubic.org/network/tx/' + transaction.transactions[0].transaction.txId"
+                                                [href]="ExplorerUrlHelper.getTransactionUrl(transaction.transactions[0].transaction.txId)"
                                                 target="_blank">{{transaction.transactions[0].transaction.txId}}
                                             </a>
                                             <mat-icon class="icon-color-link icon"
@@ -286,7 +286,7 @@
                                     </div>
                                     <div class="col-value disable-area">
                                         <span class="value display-publicid"> <a
-                                                [href]="'https://explorer.qubic.org/network/address/' + transaction.transactions[0].transaction.sourceId"
+                                                [href]="ExplorerUrlHelper.getAddressUrl(transaction.transactions[0].transaction.sourceId)"
                                                 target="_blank">
                                                 {{getAddressDisplayName(transaction.transactions[0].transaction.sourceId)}}
                                             </a>
@@ -303,7 +303,7 @@
                                         <span class="value">
                                             <ng-container
                                                 *ngIf="getAssetTransfer(transaction.transactions[0].transaction.txId); else normalDest">
-                                                <a [href]="'https://explorer.qubic.org/network/address/' + getAssetTransfer(transaction.transactions[0].transaction.txId)!.newOwnerAndPossessor"
+                                                <a [href]="ExplorerUrlHelper.getAddressUrl(getAssetTransfer(transaction.transactions[0].transaction.txId)!.newOwnerAndPossessor)"
                                                     target="_blank">
                                                     {{getAddressDisplayName(getAssetTransfer(transaction.transactions[0].transaction.txId)!.newOwnerAndPossessor)}}
                                                 </a>
@@ -312,7 +312,7 @@
                                                     [cdkCopyToClipboard]="getAssetTransfer(transaction.transactions[0].transaction.txId)!.newOwnerAndPossessor">content_copy</mat-icon>
                                             </ng-container>
                                             <ng-template #normalDest>
-                                                <a [href]="'https://explorer.qubic.org/network/address/' + transaction.transactions[0].transaction.destId"
+                                                <a [href]="ExplorerUrlHelper.getAddressUrl(transaction.transactions[0].transaction.destId)"
                                                     target="_blank">
                                                     {{getAddressDisplayName(transaction.transactions[0].transaction.destId)}}
                                                 </a>
@@ -329,7 +329,7 @@
                                     </div>
                                     <div class="col-value disable-area">
                                         <span class="value"> <a
-                                                [href]="'https://explorer.qubic.org/network/tick/' + transaction.tickNumber"
+                                                [href]="ExplorerUrlHelper.getTickUrl(transaction.tickNumber)"
                                                 target="_blank">{{ transaction.tickNumber | number: '1.0-0' }}
                                             </a>
                                         </span>

--- a/src/app/balance/balance.component.ts
+++ b/src/app/balance/balance.component.ts
@@ -16,6 +16,7 @@ import { AssetTransfer } from '../services/api.model';
 import { shortenAddress, getDisplayName, getShortDisplayName, getCompactDisplayName, EMPTY_QUBIC_ADDRESS } from '../utils/address.utils';
 import { AddressNameService } from '../services/address-name.service';
 import { AddressNameResult } from '../services/apis/static/qubic-static.model';
+import { ExplorerUrlHelper } from '../services/explorer-url.helper';
 
 @Component({
   selector: 'app-balance',
@@ -25,6 +26,7 @@ import { AddressNameResult } from '../services/apis/static/qubic-static.model';
 export class BalanceComponent implements OnInit {
 
   shortenAddress = shortenAddress;
+  ExplorerUrlHelper = ExplorerUrlHelper;
   public accountBalances: BalanceResponse[] = [];
   public seedFilterFormControl: FormControl = new FormControl('');
   public currentTick = 0;

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -224,10 +224,10 @@
       (click)="receive(publicId)">
       <mat-icon>qr_code_2</mat-icon>
     </button>
-    <a mat-icon-button class="icon-color-link" [href]="'https://explorer.qubic.org/network/address/' + publicId"
-      target="_blank" title="explorer.qubic.org">
+    <button mat-icon-button class="icon-color-link" (click)="openExplorer(publicId)"
+      [title]="t('seedOverviewComponent.table.actions.openExplorer')">
       <mat-icon>explore</mat-icon>
-    </a>
+    </button>
     <br *ngIf="walletService.privateKey && !isTable">
     <button mat-icon-button class="icon-color-link" [title]="t('seedOverviewComponent.table.actions.revealSeed')"
       (click)="reveal(publicId)">

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -24,6 +24,7 @@ import { MatSlideToggleChange } from '@angular/material/slide-toggle';
 import { DeviceDetectorService } from 'ngx-device-detector';
 import { OkDialog } from 'src/app/core/ok-dialog/ok-dialog.component';
 import { LatestStatsResponse } from '../services/apis/stats/api.stats.model';
+import { ExplorerUrlHelper } from '../services/explorer-url.helper';
 
 
 @Component({
@@ -355,6 +356,10 @@ export class MainComponent implements AfterViewInit {
 
   openAssetsPage() {
     this.router.navigate(['/assets-area']);
+  }
+
+  openExplorer(publicId: string) {
+    window.open(ExplorerUrlHelper.getAddressUrl(publicId), '_blank');
   }
 
 

--- a/src/app/services/explorer-url.helper.ts
+++ b/src/app/services/explorer-url.helper.ts
@@ -1,0 +1,33 @@
+import { environment } from '../../environments/environment';
+
+/**
+ * Helper class for building Qubic Explorer URLs
+ */
+export class ExplorerUrlHelper {
+  /**
+   * Get the URL for an address page
+   * @param address The Qubic address/public ID
+   * @returns Full URL to the address page on the explorer
+   */
+  static getAddressUrl(address: string): string {
+    return `${environment.explorerUrl}/network/address/${address}`;
+  }
+
+  /**
+   * Get the URL for a transaction page
+   * @param txId The transaction ID
+   * @returns Full URL to the transaction page on the explorer
+   */
+  static getTransactionUrl(txId: string): string {
+    return `${environment.explorerUrl}/network/tx/${txId}`;
+  }
+
+  /**
+   * Get the URL for a tick page
+   * @param tick The tick number
+   * @returns Full URL to the tick page on the explorer
+   */
+  static getTickUrl(tick: number | string): string {
+    return `${environment.explorerUrl}/network/tick/${tick}`;
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -4,7 +4,7 @@ export const environment = {
   apiQliUrl: 'https://api.qubic.li',
   apiUrl: 'https://rpc.qubic.org',
   staticApiUrl: 'https://static.qubic.org',
-  explorer: 'https://explorer.qubic.org/network/address/',
+  explorerUrl: 'https://explorer.qubic.org',
   assetsFees: 100
 };
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,6 +4,6 @@ export const environment = {
     apiQliUrl: 'http://localhost:7003',
     apiUrl: 'http://localhost:7004',
     staticApiUrl: 'https://static.qubic.org',
-    explorer: 'https://explorer.qubic.org/network/address/',
+    explorerUrl: 'https://explorer.qubic.org',
     assetsFees: 100
 };


### PR DESCRIPTION
- Change Dashboard explorer link from <a> to <button> to fix blue color in light theme
- Create ExplorerUrlHelper utility class with methods for address, transaction, and tick URLs
- Replace all hardcoded explorer URLs across components (main, assets, balance)