### PR TITLE
fix: error snackbar text not visible in light mode for unlock vault

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -353,15 +353,6 @@ mat-dialog-actions.mat-mdc-dialog-actions {
   align-items: center;
 }
 
-mat-snack-bar-container.error .mdc-snackbar__surface {
-  background-color: #faa0a0;
-
-  .mdc-button__label,
-  .mat-mdc-snack-bar-label .mdc-snackbar__label {
-    color: black;
-  }
-}
-
 .content_container {
   padding: 24px;
   display: flex;


### PR DESCRIPTION
Fixed error snackbar text visibility issue in light mode (e.g., wrong password on import/unlock). Removed error-specific styling to use the same styling as dark mode for consistent appearance across all snackbars.