### PR TITLE
fix: handle undefined response in dev-proxy error callback

### DIFF
--- a/dev-proxy.js
+++ b/dev-proxy.js
@@ -28,7 +28,7 @@ function createProxy(targetURL, port) {
             request({ url: targetURL + req.url, method: req.method, json: req.body, headers: {'Authorization': req.header('Authorization')} },
                 function (error, response, body) {
                     if (error) {
-                        console.error('error: ' + response.statusCode);
+                        console.error('error: ' + (response ? response.statusCode : error.message));
                     }
                 }).pipe(res);
         }


### PR DESCRIPTION
Prevents crash when network errors occur and response object is undefined. Now displays the actual error message instead of crashing.