### PR TITLE
fix: strengthen seed generation with crypto.getRandomValues()

### DIFF
--- a/src/app/public/create-vault/create-vault.component.ts
+++ b/src/app/public/create-vault/create-vault.component.ts
@@ -22,6 +22,7 @@ import { IDecodedSeed } from 'src/app/model/seed';
 import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { generateSeed } from 'src/app/utils/seed.utils';
 
 @Component({
   selector: 'qli-create-vault',
@@ -150,13 +151,7 @@ export class CreateVaultComponent extends QubicDialogWrapper implements OnDestro
   }
 
   private seedGen(): string {
-    const letters = 'abcdefghijklmnopqrstuvwxyz';
-    const letterSize = letters.length;
-    let seed = '';
-    for (let i = 0; i < 55; i++) {
-      seed += letters[Math.floor(Math.random() * letterSize)];
-    }
-    return seed;
+    return generateSeed();
   }
 
   public createVault() {

--- a/src/app/utils/seed.utils.spec.ts
+++ b/src/app/utils/seed.utils.spec.ts
@@ -1,0 +1,32 @@
+import { generateSeed } from './seed.utils';
+
+describe('generateSeed', () => {
+  it('should return a 55-character string', () => {
+    const seed = generateSeed();
+    expect(seed.length).toBe(55);
+  });
+
+  it('should only contain lowercase letters', () => {
+    const seed = generateSeed();
+    expect(seed).toMatch(/^[a-z]{55}$/);
+  });
+
+  it('should generate different seeds on successive calls', () => {
+    const seeds = new Set(Array.from({ length: 50 }, () => generateSeed()));
+    expect(seeds.size).toBe(50);
+  });
+
+  it('should use crypto.getRandomValues', () => {
+    const spy = spyOn(crypto, 'getRandomValues').and.callThrough();
+    generateSeed();
+    expect(spy).toHaveBeenCalledWith(jasmine.any(Uint8Array));
+    expect((spy.calls.first().args[0] as Uint8Array).length).toBe(55);
+  });
+
+  it('should use all letters of the alphabet', () => {
+    // Generate enough seeds that every letter should appear at least once
+    const combined = Array.from({ length: 100 }, () => generateSeed()).join('');
+    const uniqueChars = new Set(combined.split(''));
+    expect(uniqueChars.size).toBe(26);
+  });
+});

--- a/src/app/utils/seed.utils.ts
+++ b/src/app/utils/seed.utils.ts
@@ -1,0 +1,13 @@
+const SEED_LENGTH = 55;
+const SEED_ALPHABET = 'abcdefghijklmnopqrstuvwxyz';
+
+/**
+ * Generates a cryptographically secure random seed.
+ * Uses crypto.getRandomValues() to draw from the OS entropy pool.
+ *
+ * @returns A 55-character lowercase alphabetic seed
+ */
+export function generateSeed(): string {
+  const randomBytes = crypto.getRandomValues(new Uint8Array(SEED_LENGTH));
+  return Array.from(randomBytes, (byte) => SEED_ALPHABET[byte % SEED_ALPHABET.length]).join('');
+}


### PR DESCRIPTION
Hey! Noticed that `seedGen()` in `CreateVaultComponent` uses `Math.random()` for generating wallet seeds. Swapped it out for `crypto.getRandomValues()` which pulls from the OS entropy pool — much better fit for a wallet context.

Also extracted the logic into `src/app/utils/seed.utils.ts` so it's reusable and testable, with a spec file covering length, character set, uniqueness, and that it's actually calling the crypto API.

Note: the existing Karma test runner seems to have a bootstrapping issue (fails before any tests execute), so the spec couldn't be verified locally — but the build passes clean.

Small change, just the one function. Happy to adjust if needed!