### PR TITLE
fix: repair karma test runner and fix broken specs

### DIFF
--- a/src/app/assets/assets.component.spec.ts
+++ b/src/app/assets/assets.component.spec.ts
@@ -1,7 +1,19 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatTableModule } from '@angular/material/table';
+import { DecimalPipe } from '@angular/common';
+import { TranslocoModule, provideTransloco } from '@ngneat/transloco';
+import { BehaviorSubject, of } from 'rxjs';
 
 import { AssetsComponent } from './assets.component';
-import {size} from "@ngneat/transloco";
+import { ApiService } from '../services/api.service';
+import { UpdaterService } from '../services/updater-service';
+import { TransactionService } from '../services/transaction.service';
+import { QubicStaticService } from '../services/apis/static/qubic-static.service';
 
 describe('AssetsComponent', () => {
   let component: AssetsComponent;
@@ -9,7 +21,42 @@ describe('AssetsComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [AssetsComponent]
+      declarations: [AssetsComponent],
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        NoopAnimationsModule,
+        MatSnackBarModule,
+        MatDialogModule,
+        MatTableModule,
+        TranslocoModule,
+      ],
+      providers: [
+        DecimalPipe,
+        { provide: ApiService, useValue: {} },
+        {
+          provide: UpdaterService,
+          useValue: {
+            internalApiBalances: new BehaviorSubject([]),
+            currentTick: new BehaviorSubject(0),
+            forceLoadAssets: () => {},
+          },
+        },
+        { provide: TransactionService, useValue: {} },
+        {
+          provide: QubicStaticService,
+          useValue: {
+            getAddressName: () => of(null),
+            smartContracts$: new BehaviorSubject([]),
+          },
+        },
+        provideTransloco({
+          config: {
+            defaultLang: 'en',
+            availableLangs: ['en'],
+          },
+        }),
+      ],
     });
     fixture = TestBed.createComponent(AssetsComponent);
     component = fixture.componentInstance;
@@ -20,4 +67,3 @@ describe('AssetsComponent', () => {
     expect(component).toBeTruthy();
   });
 });
-

--- a/src/app/navigation/navigation.component.spec.ts
+++ b/src/app/navigation/navigation.component.spec.ts
@@ -1,13 +1,20 @@
 import { LayoutModule } from '@angular/cdk/layout';
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { TranslocoModule, provideTransloco } from '@ngneat/transloco';
+import { BehaviorSubject } from 'rxjs';
 
 import { NavigationComponent } from './navigation.component';
+import { UpdaterService } from '../services/updater-service';
+import { EnvironmentService } from '../services/env.service';
 
 describe('NavigationComponent', () => {
   let component: NavigationComponent;
@@ -17,6 +24,8 @@ describe('NavigationComponent', () => {
     TestBed.configureTestingModule({
       declarations: [NavigationComponent],
       imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
         NoopAnimationsModule,
         LayoutModule,
         MatButtonModule,
@@ -24,7 +33,26 @@ describe('NavigationComponent', () => {
         MatListModule,
         MatSidenavModule,
         MatToolbarModule,
-      ]
+        MatSnackBarModule,
+        TranslocoModule,
+      ],
+      providers: [
+        {
+          provide: UpdaterService,
+          useValue: {
+            latestStats: new BehaviorSubject({}),
+            currentTick: new BehaviorSubject(0),
+            errorStatus: new BehaviorSubject(''),
+          },
+        },
+        { provide: EnvironmentService, useValue: { isElectron: false } },
+        provideTransloco({
+          config: {
+            defaultLang: 'en',
+            availableLangs: ['en'],
+          },
+        }),
+      ],
     }).compileComponents();
   }));
 

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -3,6 +3,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/spec",
+    "allowJs": false,
     "types": [
       "jasmine"
     ]


### PR DESCRIPTION
Hey! Noticed `yarn test` wasn't working — the karma builder was failing before any tests could run.

**Root cause:** `allowJs: true` in `tsconfig.json` triggers a known Angular 16 karma builder bug where the test bootstrap data URI can't be compiled. Setting `allowJs: false` in `tsconfig.spec.json` fixes it (there are no `.js` files in `src/` anyway).

Also updated the `AssetsComponent` and `NavigationComponent` specs — they were missing test module imports and service mocks, so they'd fail even once the runner was working. All 15 tests pass now.

Ref: https://github.com/angular/angular-cli/issues/25936