### PR TITLE
feat: filter transfer share destinations using allowTransferShares flag

### DIFF
--- a/src/app/assets/assets.component.html
+++ b/src/app/assets/assets.component.html
@@ -176,7 +176,7 @@
           title='{{ t("assetsComponent.buttons.send") }}'>
           <mat-icon>send</mat-icon>
         </button>
-        <button *ngIf="canTransferRights(group)" mat-icon-button class="icon-color-link" (click)="openTransferRightsForm(group)"
+        <button *ngIf="showTransferRightsButton(group)" mat-icon-button class="icon-color-link" (click)="openTransferRightsForm(group)"
           title='{{ t("assetsComponent.buttons.transferRights") }}'>
           <mat-icon svgIcon="transfer_rights"></mat-icon>
         </button>

--- a/src/app/assets/assets.component.ts
+++ b/src/app/assets/assets.component.ts
@@ -23,7 +23,8 @@ import { shortenAddress } from '../utils/address.utils';
 import { ExplorerUrlHelper } from '../services/explorer-url.helper';
 import { QubicStaticService } from '../services/apis/static/qubic-static.service';
 import { StaticSmartContract } from '../services/apis/static/qubic-static.model';
-import { ASSET_TRANSFER_FEE, TRANSFER_SHARE_MANAGEMENT_RIGHTS_PROCEDURE } from '../constants/qubic.constants';
+import { ASSET_TRANSFER_FEE } from '../constants/qubic.constants';
+import { canSendTransferRights } from '../utils/smart-contract.utils';
 
 // Interfaces for asset grouping
 interface GroupedAsset {
@@ -676,23 +677,16 @@ export class AssetsComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Check if a grouped asset supports transfer rights
-   * Transfer rights are available for assets with balance > 0 in contracts that support it
-   * Dynamically checks based on procedure name from backend
+   * Check if a grouped asset can show the transfer rights button.
+   * The source contract must have the procedure and the user must own shares.
    */
-  canTransferRights(group: GroupedAsset): boolean {
-    // Check if any managing contract in this group supports transfer rights
+  showTransferRightsButton(group: GroupedAsset): boolean {
     return group.managingContracts.some((mc: ManagingContract) => {
       const contract = this.smartContractsMap.get(mc.contractIndex);
       if (!contract) return false;
 
-      // Dynamically check if contract has the transfer rights procedure
-      const hasProcedure = contract.procedures.some(
-        p => p.name === TRANSFER_SHARE_MANAGEMENT_RIGHTS_PROCEDURE
-      );
-
-      // Must have procedure and positive balance
-      return hasProcedure && mc.asset.ownedAmount > 0;
+      // Source contract must have the procedure and user must own shares
+      return canSendTransferRights(contract) && mc.asset.ownedAmount > 0;
     });
   }
 

--- a/src/app/assets/transfer-rights/transfer-rights.component.ts
+++ b/src/app/assets/transfer-rights/transfer-rights.component.ts
@@ -17,7 +17,7 @@ import { TransactionService } from '../../services/transaction.service';
 import { UpdaterService } from '../../services/updater-service';
 import { ApiLiveService } from '../../services/apis/live/api.live.service';
 import { QubicStaticService } from '../../services/apis/static/qubic-static.service';
-import { StaticSmartContract, SmartContractProcedure } from '../../services/apis/static/qubic-static.model';
+import { StaticSmartContract } from '../../services/apis/static/qubic-static.model';
 
 import { QubicTransaction } from '@qubic-lib/qubic-ts-library/dist/qubic-types/QubicTransaction';
 import { QubicDefinitions } from '@qubic-lib/qubic-ts-library/dist/QubicDefinitions';
@@ -25,7 +25,7 @@ import { PublicKey } from '@qubic-lib/qubic-ts-library/dist/qubic-types/PublicKe
 import { DynamicPayload } from '@qubic-lib/qubic-ts-library/dist/qubic-types/DynamicPayload';
 
 import { shortenAddress } from '../../utils/address.utils';
-import { TRANSFER_SHARE_MANAGEMENT_RIGHTS_PROCEDURE } from '../../constants/qubic.constants';
+import { findTransferRightsProcedure, canReceiveTransferRights } from '../../utils/smart-contract.utils';
 
 /**
  * Interface for contracts that can manage assets
@@ -279,8 +279,8 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
         continue;
       }
 
-      // Check if contract supports transfer rights
-      const procedure = this.findTransferRightsProcedure(contract);
+      // Check if contract has the transfer rights procedure
+      const procedure = findTransferRightsProcedure(contract);
       if (!procedure) {
         continue;
       }
@@ -373,9 +373,11 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
   private buildDestinationContractOptions(): void {
     const contracts: ManagingContractOption[] = [];
 
-    // Dynamically find ALL contracts that support the transfer rights procedure
+    // Find contracts that allow transfer shares and have the procedure
     for (const [contractIndex, contract] of this.smartContractsMap.entries()) {
-      const procedure = this.findTransferRightsProcedure(contract);
+      if (!canReceiveTransferRights(contract)) continue;
+
+      const procedure = findTransferRightsProcedure(contract);
 
       if (procedure) {
         // Validate procedure fee exists and is valid
@@ -403,15 +405,6 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
     this.filteredDestinationContracts = this.destinationContracts;
   }
 
-  /**
-   * Find transfer rights procedure in a contract
-   * Uses dynamic procedure name from constants
-   */
-  private findTransferRightsProcedure(contract: StaticSmartContract): SmartContractProcedure | null {
-    return contract.procedures.find(p =>
-      p.name === TRANSFER_SHARE_MANAGEMENT_RIGHTS_PROCEDURE
-    ) ?? null;
-  }
 
   /**
    * Handle source contract selection change

--- a/src/app/constants/qubic.constants.ts
+++ b/src/app/constants/qubic.constants.ts
@@ -28,3 +28,4 @@ export const ASSET_TRANSFER_FEE = QubicDefinitions.QX_TRANSFER_ASSET_FEE;
  * Used to dynamically find this procedure in smart contracts JSON
  */
 export const TRANSFER_SHARE_MANAGEMENT_RIGHTS_PROCEDURE = 'Transfer Share Management Rights';
+

--- a/src/app/services/apis/static/qubic-static.model.ts
+++ b/src/app/services/apis/static/qubic-static.model.ts
@@ -18,6 +18,7 @@ export interface StaticSmartContract {
   address: string;
   procedures: SmartContractProcedure[];
   website?: string;
+  allowTransferShares?: boolean;
 }
 
 export interface GetSmartContractsResponse {

--- a/src/app/utils/smart-contract.utils.ts
+++ b/src/app/utils/smart-contract.utils.ts
@@ -1,0 +1,25 @@
+import { SmartContractProcedure, StaticSmartContract } from '../services/apis/static/qubic-static.model';
+import { TRANSFER_SHARE_MANAGEMENT_RIGHTS_PROCEDURE } from '../constants/qubic.constants';
+
+/**
+ * Find the Transfer Share Management Rights procedure in a contract.
+ */
+export function findTransferRightsProcedure(contract: StaticSmartContract): SmartContractProcedure | null {
+  return contract.procedures.find(p =>
+    p.name.toLowerCase() === TRANSFER_SHARE_MANAGEMENT_RIGHTS_PROCEDURE.toLowerCase()
+  ) ?? null;
+}
+
+/**
+ * Check if a smart contract can send transfer rights (used as source).
+ */
+export function canSendTransferRights(contract: StaticSmartContract): boolean {
+  return !!findTransferRightsProcedure(contract);
+}
+
+/**
+ * Check if a smart contract can receive transfer rights (used as destination).
+ */
+export function canReceiveTransferRights(contract: StaticSmartContract): boolean {
+  return !!contract.allowTransferShares;
+}


### PR DESCRIPTION
Extract shared helper and use allowTransferShares from smart_contracts.json to control destination contract eligibility in transfer rights form.