### PR TITLE
fix: add missing transferRights.form.amount translation

### DIFF
--- a/src/assets/i18n/cn.json
+++ b/src/assets/i18n/cn.json
@@ -152,6 +152,7 @@
       "selectAsset": "选择资产",
       "sourceContract": "源合约",
       "destinationContract": "目标合约",
+      "amount": "数量",
       "procedureFee": "程序费用",
       "tick": "刻度",
       "tickOverwrite": "手动刻度覆盖",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -152,6 +152,7 @@
       "selectAsset": "Asset auswählen",
       "sourceContract": "Quellvertrag",
       "destinationContract": "Zielvertrag",
+      "amount": "Menge",
       "procedureFee": "Verfahrensgebühr",
       "tick": "Tick",
       "tickOverwrite": "Manuelles Tick-Override",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -153,6 +153,7 @@
       "selectAsset": "Select Asset",
       "sourceContract": "Source Contract",
       "destinationContract": "Destination Contract",
+      "amount": "Amount",
       "balance": "Your balance after deducting transfer fees ({{fee}} Qubic) will be:",
       "tick": "Tick",
       "tickOverwrite": "Manual Tick Override",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -152,6 +152,7 @@
       "selectAsset": "Seleccionar Activo",
       "sourceContract": "Contrato de Origen",
       "destinationContract": "Contrato de Destino",
+      "amount": "Cantidad",
       "procedureFee": "Tarifa del Procedimiento",
       "tick": "Tick",
       "tickOverwrite": "Anulación Manual de Tick",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -152,6 +152,7 @@
       "selectAsset": "Sélectionner un Actif",
       "sourceContract": "Contrat Source",
       "destinationContract": "Contrat de Destination",
+      "amount": "Montant",
       "procedureFee": "Frais de Procédure",
       "tick": "Tick",
       "tickOverwrite": "Remplacement Manuel du Tick",

--- a/src/assets/i18n/jp.json
+++ b/src/assets/i18n/jp.json
@@ -152,6 +152,7 @@
       "selectAsset": "資産を選択",
       "sourceContract": "ソース契約",
       "destinationContract": "宛先契約",
+      "amount": "数量",
       "procedureFee": "手続き手数料",
       "tick": "ティック",
       "tickOverwrite": "手動ティックオーバーライド",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -152,6 +152,7 @@
       "selectAsset": "Activa Selecteren",
       "sourceContract": "Broncontract",
       "destinationContract": "Bestemmingscontract",
+      "amount": "Aantal",
       "procedureFee": "Procedurekosten",
       "tick": "Tick",
       "tickOverwrite": "Handmatige Tick Overschrijving",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -152,6 +152,7 @@
       "selectAsset": "Selecionar Ativo",
       "sourceContract": "Contrato de Origem",
       "destinationContract": "Contrato de Destino",
+      "amount": "Quantidade",
       "procedureFee": "Taxa de Procedimento",
       "tick": "Tick",
       "tickOverwrite": "Substituição Manual de Tick",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -152,6 +152,7 @@
       "selectAsset": "Выбрать Актив",
       "sourceContract": "Исходный Контракт",
       "destinationContract": "Целевой Контракт",
+      "amount": "Количество",
       "procedureFee": "Комиссия за Процедуру",
       "tick": "Тик",
       "tickOverwrite": "Ручная Замена Тика",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -152,6 +152,7 @@
       "selectAsset": "Varlık Seç",
       "sourceContract": "Kaynak Sözleşme",
       "destinationContract": "Hedef Sözleşme",
+      "amount": "Miktar",
       "procedureFee": "İşlem Ücreti",
       "tick": "Tick",
       "tickOverwrite": "Manuel Tick Geçersiz Kılma",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -152,6 +152,7 @@
       "selectAsset": "Chọn Tài sản",
       "sourceContract": "Hợp đồng Nguồn",
       "destinationContract": "Hợp đồng Đích",
+      "amount": "Số lượng",
       "procedureFee": "Phí Thủ tục",
       "tick": "Tick",
       "tickOverwrite": "Ghi đè Tick Thủ công",


### PR DESCRIPTION
## Summary
- Added missing `transferRights.form.amount` i18n key to all 11 language files
- The amount field label in the transfer rights form was showing the raw key instead of a translated string