### PR TITLE
feat: support RevokeAssetManagementRights procedure

### DIFF
--- a/src/app/assets/assets.component.ts
+++ b/src/app/assets/assets.component.ts
@@ -24,7 +24,7 @@ import { ExplorerUrlHelper } from '../services/explorer-url.helper';
 import { QubicStaticService } from '../services/apis/static/qubic-static.service';
 import { StaticSmartContract } from '../services/apis/static/qubic-static.model';
 import { ASSET_TRANSFER_FEE } from '../constants/qubic.constants';
-import { canSendTransferRights } from '../utils/smart-contract.utils';
+import { hasManagementRightsProcedure } from '../utils/smart-contract.utils';
 
 // Interfaces for asset grouping
 interface GroupedAsset {
@@ -686,16 +686,18 @@ export class AssetsComponent implements OnInit, OnDestroy {
       if (!contract) return false;
 
       // Source contract must have the procedure and user must own shares
-      return canSendTransferRights(contract) && mc.asset.ownedAmount > 0;
+      return hasManagementRightsProcedure(contract) && mc.asset.ownedAmount > 0;
     });
   }
 
   /**
-   * Navigate to Transfer Rights form with first managing contract pre-selected
+   * Navigate to Transfer Rights form with first eligible managing contract pre-selected
    */
   openTransferRightsForm(group: GroupedAsset): void {
-    // Get the first managing contract
-    const firstContract = group.managingContracts[0];
+    const firstContract = group.managingContracts.find((mc: ManagingContract) => {
+      const contract = this.smartContractsMap.get(mc.contractIndex);
+      return contract ? hasManagementRightsProcedure(contract) && mc.asset.ownedAmount > 0 : false;
+    });
 
     if (firstContract) {
       this.router.navigate(['/assets-area/transfer-rights'], {

--- a/src/app/assets/transfer-rights/transfer-rights.component.html
+++ b/src/app/assets/transfer-rights/transfer-rights.component.html
@@ -96,6 +96,9 @@
                   {{ t("transferRights.errors.contractsEqual") }}
                 </mat-error>
               </mat-form-field>
+              <div *ngIf="selectedSourceContract?.procedureType === 'revoke'" class="info-note">
+                * {{ t("transferRights.form.revokeOnlyHint", { contract: selectedSourceContract?.contractName }) }}
+              </div>
             </div>
           </div>
 

--- a/src/app/assets/transfer-rights/transfer-rights.component.html
+++ b/src/app/assets/transfer-rights/transfer-rights.component.html
@@ -107,7 +107,7 @@
               <!-- Number of Shares (equivalent to Amount field) -->
               <mat-form-field appearance="fill" class="full-width">
                 <mat-label>{{ t("transferRights.form.amount") }}</mat-label>
-                <input matInput type="number" formControlName="numberOfShares" min="1">
+                <input matInput appAmountInput formControlName="numberOfShares" maxlength="19">
                 <button *ngIf="transferRightsForm.controls['numberOfShares'].value" matSuffix mat-icon-button
                   aria-label="Clear" (click)="transferRightsForm.controls['numberOfShares'].setValue(null)"
                   type="button">

--- a/src/app/assets/transfer-rights/transfer-rights.component.scss
+++ b/src/app/assets/transfer-rights/transfer-rights.component.scss
@@ -63,6 +63,14 @@
     }
   }
 
+  .info-note {
+    margin-top: -10px;
+    margin-bottom: 15px;
+    font-size: 0.9em;
+    opacity: 0.7;
+    font-style: italic;
+  }
+
   // Padding for action buttons
   .padding button {
     margin: 10px;

--- a/src/app/assets/transfer-rights/transfer-rights.component.ts
+++ b/src/app/assets/transfer-rights/transfer-rights.component.ts
@@ -373,9 +373,8 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
       assetOption.owningContracts.sort((a, b) => b.availableBalance - a.availableBalance);
     }
 
-    // Convert to arrays and sort alphabetically
-    this.sourceContracts = Array.from(contractMap.values())
-      .sort((a, b) => a.contractName.localeCompare(b.contractName, undefined, { sensitivity: 'base' }));
+    // Convert to array (only used for length checks in template)
+    this.sourceContracts = Array.from(contractMap.values());
 
     this.assets = Array.from(assetMap.values())
       .sort((a, b) => {

--- a/src/app/assets/transfer-rights/transfer-rights.component.ts
+++ b/src/app/assets/transfer-rights/transfer-rights.component.ts
@@ -25,7 +25,7 @@ import { PublicKey } from '@qubic-lib/qubic-ts-library/dist/qubic-types/PublicKe
 import { DynamicPayload } from '@qubic-lib/qubic-ts-library/dist/qubic-types/DynamicPayload';
 
 import { shortenAddress } from '../../utils/address.utils';
-import { findTransferRightsProcedure, canReceiveTransferRights } from '../../utils/smart-contract.utils';
+import { findManagementRightsProcedure, findTransferRightsProcedure, canReceiveTransferRights } from '../../utils/smart-contract.utils';
 
 /**
  * Interface for contracts that can manage assets
@@ -44,6 +44,7 @@ interface ManagingContractOption {
  */
 interface SourceContractOption extends ManagingContractOption {
   asset: QubicAsset;
+  procedureType: 'transfer' | 'revoke';
 }
 
 /**
@@ -244,8 +245,11 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
       // Process assets into source contract options
       this.buildSourceContractOptions(allAssets);
 
-      // Build destination contract options (all contracts with transfer rights procedure)
+      // Build destination contract options
       this.buildDestinationContractOptions();
+
+      // Re-validate current form selections against rebuilt lists
+      this.revalidateFormSelections();
 
     } catch (error) {
       console.error('Error loading assets:', error);
@@ -257,6 +261,35 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
     } finally {
       this.isLoading = false;
       this.isLoadingAssets = false;
+    }
+  }
+
+  /**
+   * Re-validate current form selections after options are rebuilt.
+   * Clears selections that are no longer present in the updated lists.
+   */
+  private revalidateFormSelections(): void {
+    const currentAsset = this.transferRightsForm.get('selectedAsset')?.value as AssetOption | null;
+    if (currentAsset) {
+      const stillExists = this.assets.find(a => this.compareAssets(a, currentAsset));
+      if (!stillExists) {
+        this.transferRightsForm.patchValue({ selectedAsset: '', sourceContract: '', destinationContract: '' });
+        this.selectedAsset = null;
+        this.selectedSourceContract = null;
+        this.selectedDestinationContract = null;
+        return;
+      }
+    }
+
+    const currentSource = this.transferRightsForm.get('sourceContract')?.value as SourceContractOption | null;
+    if (currentSource) {
+      const stillExists = this.sourceContracts.find(c => c.contractIndex === currentSource.contractIndex &&
+        c.asset.publicId === currentSource.asset.publicId);
+      if (!stillExists) {
+        this.transferRightsForm.patchValue({ sourceContract: '', destinationContract: '' });
+        this.selectedSourceContract = null;
+        this.selectedDestinationContract = null;
+      }
     }
   }
 
@@ -279,14 +312,15 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
         continue;
       }
 
-      // Check if contract has the transfer rights procedure
-      const procedure = findTransferRightsProcedure(contract);
-      if (!procedure) {
+      // Check if contract has a management rights procedure (transfer or revoke)
+      const result = findManagementRightsProcedure(contract);
+      if (!result) {
         continue;
       }
 
-      // Validate procedure fee exists and is valid
-      if (procedure.fee === undefined || procedure.fee === null || procedure.fee < 0) {
+      const { procedure, type: procedureType } = result;
+
+      if (procedure.fee == null || procedure.fee < 0) {
         console.warn(`Contract ${contract.name} has invalid procedure fee:`, procedure.fee);
         continue;
       }
@@ -302,7 +336,8 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
           procedureId: procedure.id,
           procedureFee: procedure.fee,
           availableBalance: asset.ownedAmount,
-          asset: asset
+          asset: asset,
+          procedureType: procedureType
         };
         contractMap.set(contractKey, sourceContract);
 
@@ -367,22 +402,23 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
 
   /**
    * Build destination contract options
-   * Lists all contracts that support transfer rights procedure
-   * Dynamically discovers contracts based on procedure availability
+   * Lists all contracts that could be valid destinations.
+   * The actual filtering depends on the selected source contract's procedure type
+   * and is applied in onSourceContractChange.
    */
   private buildDestinationContractOptions(): void {
     const contracts: ManagingContractOption[] = [];
 
-    // Find contracts that allow transfer shares and have the procedure
     for (const [contractIndex, contract] of this.smartContractsMap.entries()) {
-      if (!canReceiveTransferRights(contract)) continue;
+      // A contract is a valid destination if it has allowTransferShares AND a TransferShareManagementRights procedure,
+      // OR if it is QX (which is always a valid destination for RevokeAssetManagementRights)
+      const hasAllowTransfer = canReceiveTransferRights(contract);
+      const transferProc = findTransferRightsProcedure(contract);
+      const isQx = contract.address === QubicDefinitions.QX_ADDRESS;
 
-      const procedure = findTransferRightsProcedure(contract);
-
-      if (procedure) {
-        // Validate procedure fee exists and is valid
-        if (procedure.fee === undefined || procedure.fee === null || procedure.fee < 0) {
-          console.warn(`Contract ${contract.name} has invalid procedure fee:`, procedure.fee);
+      if ((hasAllowTransfer && transferProc) || isQx) {
+        if (transferProc && (transferProc.fee == null || transferProc.fee < 0)) {
+          console.warn(`Contract ${contract.name} has invalid procedure fee:`, transferProc.fee);
           continue;
         }
 
@@ -390,9 +426,9 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
           contractIndex: contractIndex,
           contractName: contract.label || contract.name,
           address: contract.address,
-          procedureId: procedure.id,
-          procedureFee: procedure.fee,
-          availableBalance: 0 // Not applicable for destination
+          procedureId: transferProc?.id ?? 0,
+          procedureFee: transferProc?.fee ?? 0,
+          availableBalance: 0
         });
       }
     }
@@ -405,37 +441,47 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
     this.filteredDestinationContracts = this.destinationContracts;
   }
 
-
   /**
    * Handle source contract selection change
+   * Filters destination contracts based on the source contract's procedure type:
+   * - RevokeAssetManagementRights: destination is only QX
+   * - TransferShareManagementRights: destination is contracts with allowTransferShares AND TransferShareManagementRights
    */
   private onSourceContractChange(sourceContract: SourceContractOption | null): void {
     this.selectedSourceContract = sourceContract;
 
     if (sourceContract) {
-      // Filter destination contracts to exclude the source contract
-      this.filteredDestinationContracts = this.destinationContracts.filter(
-        dest => dest.contractIndex !== sourceContract.contractIndex
-      );
+      if (sourceContract.procedureType === 'revoke') {
+        // Revoke: destination can only be QX
+        this.filteredDestinationContracts = this.destinationContracts.filter(
+          dest => dest.address === QubicDefinitions.QX_ADDRESS
+        );
+      } else {
+        // Transfer: destination must have allowTransferShares AND TransferShareManagementRights procedure
+        // Exclude the source contract itself
+        this.filteredDestinationContracts = this.destinationContracts.filter(dest => {
+          if (dest.contractIndex === sourceContract.contractIndex) return false;
+          const contract = this.smartContractsMap.get(dest.contractIndex);
+          if (!contract) return false;
+          return canReceiveTransferRights(contract) && !!findTransferRightsProcedure(contract);
+        });
+      }
 
       // Update shares validation based on available balance
       this.updateSharesValidation();
 
-      // Auto-select QX as destination if not managed by QX
-      if (sourceContract.address !== QubicDefinitions.QX_ADDRESS && !this.transferRightsForm.get('destinationContract')?.value) {
-        const qxContract = this.filteredDestinationContracts.find(c => c.address === QubicDefinitions.QX_ADDRESS);
-        if (qxContract) {
-          this.transferRightsForm.patchValue({
-            destinationContract: qxContract
-          });
-        }
-      }
-
-      // Clear destination if same as source (shouldn't happen with filtering, but keep as safety)
-      const destContract = this.transferRightsForm.get('destinationContract')?.value;
-      if (destContract && destContract.contractIndex === sourceContract.contractIndex) {
+      // Clear destination if it's no longer in the filtered list
+      const currentDest = this.transferRightsForm.get('destinationContract')?.value;
+      if (currentDest && !this.filteredDestinationContracts.some(d => d.contractIndex === currentDest.contractIndex)) {
         this.transferRightsForm.patchValue({
           destinationContract: ''
+        });
+      }
+
+      // Auto-select destination if only one option
+      if (this.filteredDestinationContracts.length === 1 && !this.transferRightsForm.get('destinationContract')?.value) {
+        this.transferRightsForm.patchValue({
+          destinationContract: this.filteredDestinationContracts[0]
         });
       }
     } else {
@@ -471,18 +517,21 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
       // Auto-select first contract if only one option
       if (this.filteredSourceContracts.length === 1) {
         this.transferRightsForm.patchValue({
-          sourceContract: this.filteredSourceContracts[0]
+          sourceContract: this.filteredSourceContracts[0],
+          destinationContract: ''
         });
       } else {
-        // Clear source contract selection
+        // Clear source and destination contract selection
         this.transferRightsForm.patchValue({
-          sourceContract: ''
+          sourceContract: '',
+          destinationContract: ''
         });
       }
     } else {
       this.filteredSourceContracts = [];
       this.transferRightsForm.patchValue({
         sourceContract: '',
+        destinationContract: '',
         numberOfShares: null
       });
     }
@@ -635,6 +684,18 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
       return;
     }
 
+    // Validate destination is consistent with procedure type
+    if (this.selectedSourceContract.procedureType === 'revoke') {
+      if (this.selectedDestinationContract.address !== QubicDefinitions.QX_ADDRESS) {
+        return;
+      }
+    } else {
+      const destContract = this.smartContractsMap.get(this.selectedDestinationContract.contractIndex);
+      if (!destContract || !canReceiveTransferRights(destContract) || !findTransferRightsProcedure(destContract)) {
+        return;
+      }
+    }
+
     // Validate fee balance
     if (!this.canPayFees()) {
       this.snackBar.open(
@@ -668,35 +729,59 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
       // Reveal seed for signing
       signSeed = await this.walletService.revealSeed(asset.publicId);
 
-      // Build payload (52 bytes total)
-      // Asset: issuer (32 bytes) + assetName (8 bytes) = 40 bytes
-      // numberOfShares: sint64 = 8 bytes
-      // newManagingContractIndex: uint32 = 4 bytes
-      const payloadBytes = new Uint8Array(52);
-      let offset = 0;
-
-      // Add issuer identity (32 bytes)
+      // Build payload based on procedure type
+      const isRevoke = this.selectedSourceContract.procedureType === 'revoke';
+      const encoder = new TextEncoder();
       const issuerPubKey = new PublicKey(asset.issuerIdentity);
       const issuerBytes = issuerPubKey.getPackageData();
-      payloadBytes.set(issuerBytes, offset);
-      offset += 32;
-
-      // Add asset name (8 bytes, padded with null bytes)
-      const encoder = new TextEncoder();
       const nameBytes = encoder.encode(asset.assetName);
-      payloadBytes.set(nameBytes.slice(0, 8), offset);
-      offset += 8;
 
-      // Add number of shares (8 bytes, signed int64, little-endian)
-      const dataView = new DataView(payloadBytes.buffer);
-      dataView.setBigInt64(offset, BigInt(numberOfShares), true);
-      offset += 8;
+      let payloadBytes: Uint8Array;
+      let dataView: DataView;
+      let offset = 0;
 
-      // Add new managing contract index (4 bytes, unsigned int32, little-endian)
-      dataView.setUint32(offset, this.selectedDestinationContract.contractIndex, true);
+      if (isRevoke) {
+        // Revoke payload (48 bytes):
+        // Asset: assetName (8 bytes) + issuer (32 bytes) = 40 bytes
+        // numberOfShares: sint64 = 8 bytes
+        payloadBytes = new Uint8Array(48);
+        dataView = new DataView(payloadBytes.buffer);
 
-      // Create payload wrapper
-      const payload = new DynamicPayload(52);
+        // Asset name (8 bytes, padded with null bytes)
+        payloadBytes.set(nameBytes.slice(0, 8), offset);
+        offset += 8;
+
+        // Issuer identity (32 bytes)
+        payloadBytes.set(issuerBytes, offset);
+        offset += 32;
+
+        // Number of shares (8 bytes, signed int64, little-endian)
+        dataView.setBigInt64(offset, BigInt(numberOfShares), true);
+      } else {
+        // Transfer payload (52 bytes):
+        // Asset: issuer (32 bytes) + assetName (8 bytes) = 40 bytes
+        // numberOfShares: sint64 = 8 bytes
+        // newManagingContractIndex: uint32 = 4 bytes
+        payloadBytes = new Uint8Array(52);
+        dataView = new DataView(payloadBytes.buffer);
+
+        // Issuer identity (32 bytes)
+        payloadBytes.set(issuerBytes, offset);
+        offset += 32;
+
+        // Asset name (8 bytes, padded with null bytes)
+        payloadBytes.set(nameBytes.slice(0, 8), offset);
+        offset += 8;
+
+        // Number of shares (8 bytes, signed int64, little-endian)
+        dataView.setBigInt64(offset, BigInt(numberOfShares), true);
+        offset += 8;
+
+        // New managing contract index (4 bytes, unsigned int32, little-endian)
+        dataView.setUint32(offset, this.selectedDestinationContract.contractIndex, true);
+      }
+
+      const payload = new DynamicPayload(payloadBytes.length);
       payload.setPayload(payloadBytes);
 
       // Build transaction

--- a/src/app/assets/transfer-rights/transfer-rights.component.ts
+++ b/src/app/assets/transfer-rights/transfer-rights.component.ts
@@ -699,18 +699,6 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
       return;
     }
 
-    // Validate destination is consistent with procedure type
-    if (this.selectedSourceContract.procedureType === 'revoke') {
-      if (this.selectedDestinationContract.address !== QubicDefinitions.QX_ADDRESS) {
-        return;
-      }
-    } else {
-      const destContract = this.smartContractsMap.get(this.selectedDestinationContract.contractIndex);
-      if (!destContract || !canReceiveTransferRights(destContract) || !findManagementRightsProcedure(destContract)) {
-        return;
-      }
-    }
-
     // Validate fee balance
     if (!this.canPayFees()) {
       this.snackBar.open(

--- a/src/app/assets/transfer-rights/transfer-rights.component.ts
+++ b/src/app/assets/transfer-rights/transfer-rights.component.ts
@@ -368,6 +368,11 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
       }
     }
 
+    // Sort owning contracts by balance descending within each asset group
+    for (const assetOption of assetMap.values()) {
+      assetOption.owningContracts.sort((a, b) => b.availableBalance - a.availableBalance);
+    }
+
     // Convert to arrays and sort alphabetically
     this.sourceContracts = Array.from(contractMap.values())
       .sort((a, b) => a.contractName.localeCompare(b.contractName, undefined, { sensitivity: 'base' }));

--- a/src/app/assets/transfer-rights/transfer-rights.component.ts
+++ b/src/app/assets/transfer-rights/transfer-rights.component.ts
@@ -25,7 +25,7 @@ import { PublicKey } from '@qubic-lib/qubic-ts-library/dist/qubic-types/PublicKe
 import { DynamicPayload } from '@qubic-lib/qubic-ts-library/dist/qubic-types/DynamicPayload';
 
 import { shortenAddress } from '../../utils/address.utils';
-import { findManagementRightsProcedure, findTransferRightsProcedure, canReceiveTransferRights } from '../../utils/smart-contract.utils';
+import { findManagementRightsProcedure, canReceiveTransferRights } from '../../utils/smart-contract.utils';
 
 /**
  * Interface for contracts that can manage assets
@@ -270,27 +270,37 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
    */
   private revalidateFormSelections(): void {
     const currentAsset = this.transferRightsForm.get('selectedAsset')?.value as AssetOption | null;
-    if (currentAsset) {
-      const stillExists = this.assets.find(a => this.compareAssets(a, currentAsset));
-      if (!stillExists) {
-        this.transferRightsForm.patchValue({ selectedAsset: '', sourceContract: '', destinationContract: '' });
-        this.selectedAsset = null;
-        this.selectedSourceContract = null;
-        this.selectedDestinationContract = null;
-        return;
-      }
+    if (!currentAsset) return;
+
+    const newAsset = this.assets.find(a => this.compareAssets(a, currentAsset));
+    if (!newAsset) {
+      this.transferRightsForm.patchValue({ selectedAsset: '', sourceContract: '', destinationContract: '' });
+      this.selectedAsset = null;
+      this.selectedSourceContract = null;
+      this.selectedDestinationContract = null;
+      return;
     }
 
+    // Update form value and filtered source list with new object references
+    this.selectedAsset = newAsset;
+    this.filteredSourceContracts = newAsset.owningContracts;
+    this.transferRightsForm.patchValue({ selectedAsset: newAsset }, { emitEvent: false });
+
     const currentSource = this.transferRightsForm.get('sourceContract')?.value as SourceContractOption | null;
-    if (currentSource) {
-      const stillExists = this.sourceContracts.find(c => c.contractIndex === currentSource.contractIndex &&
-        c.asset.publicId === currentSource.asset.publicId);
-      if (!stillExists) {
-        this.transferRightsForm.patchValue({ sourceContract: '', destinationContract: '' });
-        this.selectedSourceContract = null;
-        this.selectedDestinationContract = null;
-      }
+    if (!currentSource) return;
+
+    const newSource = newAsset.owningContracts.find(c => c.contractIndex === currentSource.contractIndex);
+    if (!newSource) {
+      this.transferRightsForm.patchValue({ sourceContract: '', destinationContract: '' });
+      this.selectedSourceContract = null;
+      this.selectedDestinationContract = null;
+      return;
     }
+
+    // Update form value with new object reference and re-filter destinations
+    this.selectedSourceContract = newSource;
+    this.transferRightsForm.patchValue({ sourceContract: newSource }, { emitEvent: false });
+    this.onSourceContractChange(newSource);
   }
 
   /**
@@ -369,25 +379,26 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
         return a.asset.publicId.localeCompare(b.asset.publicId, undefined, { sensitivity: 'base' });
       });
 
-    // Pre-select asset and contract if we have pre-selected asset info
+    // Pre-select asset and contract only on first load
     if (this.preSelectedAsset && this.assets.length > 0) {
+      const preSelected = this.preSelectedAsset;
+      this.preSelectedAsset = null;
+
       const matchingAsset = this.assets.find(a =>
-        a.asset.publicId === this.preSelectedAsset!.publicId &&
-        a.asset.assetName === this.preSelectedAsset!.assetName &&
-        a.asset.issuerIdentity === this.preSelectedAsset!.issuerIdentity
+        a.asset.publicId === preSelected.publicId &&
+        a.asset.assetName === preSelected.assetName &&
+        a.asset.issuerIdentity === preSelected.issuerIdentity
       );
 
       if (matchingAsset) {
         // Use setTimeout to ensure the form is ready
         setTimeout(() => {
-          // First select the asset
           this.transferRightsForm.patchValue({
             selectedAsset: matchingAsset
           });
 
-          // Then find and select the matching contract
           const matchingContract = matchingAsset.owningContracts.find(c =>
-            c.contractIndex === this.preSelectedAsset!.contractIndex
+            c.contractIndex === preSelected.contractIndex
           );
 
           if (matchingContract) {
@@ -410,15 +421,15 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
     const contracts: ManagingContractOption[] = [];
 
     for (const [contractIndex, contract] of this.smartContractsMap.entries()) {
-      // A contract is a valid destination if it has allowTransferShares AND a TransferShareManagementRights procedure,
+      // A contract is a valid destination if it has allowTransferShares AND a management rights procedure,
       // OR if it is QX (which is always a valid destination for RevokeAssetManagementRights)
       const hasAllowTransfer = canReceiveTransferRights(contract);
-      const transferProc = findTransferRightsProcedure(contract);
+      const mgmtProc = findManagementRightsProcedure(contract);
       const isQx = contract.address === QubicDefinitions.QX_ADDRESS;
 
-      if ((hasAllowTransfer && transferProc) || isQx) {
-        if (transferProc && (transferProc.fee == null || transferProc.fee < 0)) {
-          console.warn(`Contract ${contract.name} has invalid procedure fee:`, transferProc.fee);
+      if ((hasAllowTransfer && mgmtProc) || isQx) {
+        if (mgmtProc && (mgmtProc.procedure.fee == null || mgmtProc.procedure.fee < 0)) {
+          console.warn(`Contract ${contract.name} has invalid procedure fee:`, mgmtProc.procedure.fee);
           continue;
         }
 
@@ -426,8 +437,8 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
           contractIndex: contractIndex,
           contractName: contract.label || contract.name,
           address: contract.address,
-          procedureId: transferProc?.id ?? 0,
-          procedureFee: transferProc?.fee ?? 0,
+          procedureId: mgmtProc?.procedure.id ?? 0,
+          procedureFee: mgmtProc?.procedure.fee ?? 0,
           availableBalance: 0
         });
       }
@@ -457,13 +468,13 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
           dest => dest.address === QubicDefinitions.QX_ADDRESS
         );
       } else {
-        // Transfer: destination must have allowTransferShares AND TransferShareManagementRights procedure
+        // Transfer: destination must have allowTransferShares AND a management rights procedure
         // Exclude the source contract itself
         this.filteredDestinationContracts = this.destinationContracts.filter(dest => {
           if (dest.contractIndex === sourceContract.contractIndex) return false;
           const contract = this.smartContractsMap.get(dest.contractIndex);
           if (!contract) return false;
-          return canReceiveTransferRights(contract) && !!findTransferRightsProcedure(contract);
+          return canReceiveTransferRights(contract) && !!findManagementRightsProcedure(contract);
         });
       }
 
@@ -691,7 +702,7 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
       }
     } else {
       const destContract = this.smartContractsMap.get(this.selectedDestinationContract.contractIndex);
-      if (!destContract || !canReceiveTransferRights(destContract) || !findTransferRightsProcedure(destContract)) {
+      if (!destContract || !canReceiveTransferRights(destContract) || !findManagementRightsProcedure(destContract)) {
         return;
       }
     }
@@ -742,18 +753,18 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
 
       if (isRevoke) {
         // Revoke payload (48 bytes):
-        // Asset: assetName (8 bytes) + issuer (32 bytes) = 40 bytes
+        // Asset: issuer (32 bytes) + assetName (8 bytes) = 40 bytes
         // numberOfShares: sint64 = 8 bytes
         payloadBytes = new Uint8Array(48);
         dataView = new DataView(payloadBytes.buffer);
 
-        // Asset name (8 bytes, padded with null bytes)
-        payloadBytes.set(nameBytes.slice(0, 8), offset);
-        offset += 8;
-
         // Issuer identity (32 bytes)
         payloadBytes.set(issuerBytes, offset);
         offset += 32;
+
+        // Asset name (8 bytes, padded with null bytes)
+        payloadBytes.set(nameBytes.slice(0, 8), offset);
+        offset += 8;
 
         // Number of shares (8 bytes, signed int64, little-endian)
         dataView.setBigInt64(offset, BigInt(numberOfShares), true);

--- a/src/app/constants/qubic.constants.ts
+++ b/src/app/constants/qubic.constants.ts
@@ -24,8 +24,14 @@ export const MAX_WALLET_ACCOUNTS = 15;
 export const ASSET_TRANSFER_FEE = QubicDefinitions.QX_TRANSFER_ASSET_FEE;
 
 /**
- * Procedure name for Transfer Share Management Rights
- * Used to dynamically find this procedure in smart contracts JSON
+ * Source identifier for Transfer Share Management Rights procedure
+ * Used to match procedures by sourceIdentifier field (case insensitive)
  */
-export const TRANSFER_SHARE_MANAGEMENT_RIGHTS_PROCEDURE = 'Transfer Share Management Rights';
+export const TRANSFER_SHARE_MANAGEMENT_RIGHTS_IDENTIFIER = 'TransferShareManagementRights';
+
+/**
+ * Source identifier for Revoke Asset Management Rights procedure
+ * Used to match procedures by sourceIdentifier field (case insensitive)
+ */
+export const REVOKE_ASSET_MANAGEMENT_RIGHTS_IDENTIFIER = 'RevokeAssetManagementRights';
 

--- a/src/app/services/apis/static/qubic-static.model.ts
+++ b/src/app/services/apis/static/qubic-static.model.ts
@@ -6,6 +6,7 @@
 export interface SmartContractProcedure {
   id: number;
   name: string;
+  sourceIdentifier?: string;
   fee?: number;
 }
 

--- a/src/app/utils/smart-contract.utils.ts
+++ b/src/app/utils/smart-contract.utils.ts
@@ -1,20 +1,48 @@
 import { SmartContractProcedure, StaticSmartContract } from '../services/apis/static/qubic-static.model';
-import { TRANSFER_SHARE_MANAGEMENT_RIGHTS_PROCEDURE } from '../constants/qubic.constants';
+import {
+  TRANSFER_SHARE_MANAGEMENT_RIGHTS_IDENTIFIER,
+  REVOKE_ASSET_MANAGEMENT_RIGHTS_IDENTIFIER,
+} from '../constants/qubic.constants';
 
 /**
- * Find the Transfer Share Management Rights procedure in a contract.
+ * Find a procedure that has a TransferShareManagementRights sourceIdentifier.
  */
 export function findTransferRightsProcedure(contract: StaticSmartContract): SmartContractProcedure | null {
-  return contract.procedures.find(p =>
-    p.name.toLowerCase() === TRANSFER_SHARE_MANAGEMENT_RIGHTS_PROCEDURE.toLowerCase()
+  return contract.procedures?.find(p =>
+    p.sourceIdentifier?.toLowerCase() === TRANSFER_SHARE_MANAGEMENT_RIGHTS_IDENTIFIER.toLowerCase()
   ) ?? null;
 }
 
 /**
- * Check if a smart contract can send transfer rights (used as source).
+ * Find a procedure that has a RevokeAssetManagementRights sourceIdentifier.
  */
-export function canSendTransferRights(contract: StaticSmartContract): boolean {
-  return !!findTransferRightsProcedure(contract);
+export function findRevokeRightsProcedure(contract: StaticSmartContract): SmartContractProcedure | null {
+  return contract.procedures?.find(p =>
+    p.sourceIdentifier?.toLowerCase() === REVOKE_ASSET_MANAGEMENT_RIGHTS_IDENTIFIER.toLowerCase()
+  ) ?? null;
+}
+
+/**
+ * Find any management rights procedure (transfer or revoke) on a contract.
+ * Returns the procedure and its type.
+ */
+export function findManagementRightsProcedure(contract: StaticSmartContract): { procedure: SmartContractProcedure; type: 'transfer' | 'revoke' } | null {
+  const transferProc = findTransferRightsProcedure(contract);
+  if (transferProc) {
+    return { procedure: transferProc, type: 'transfer' };
+  }
+  const revokeProc = findRevokeRightsProcedure(contract);
+  if (revokeProc) {
+    return { procedure: revokeProc, type: 'revoke' };
+  }
+  return null;
+}
+
+/**
+ * Check if a smart contract has a management rights procedure (TransferShareManagementRights or RevokeAssetManagementRights).
+ */
+export function hasManagementRightsProcedure(contract: StaticSmartContract): boolean {
+  return !!findManagementRightsProcedure(contract);
 }
 
 /**

--- a/src/assets/i18n/cn.json
+++ b/src/assets/i18n/cn.json
@@ -157,7 +157,8 @@
       "tick": "刻度",
       "tickOverwrite": "手动刻度覆盖",
       "maxButton": "最大",
-      "submit": "转移权利"
+      "submit": "转移权利",
+      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
     },
     "errors": {
       "assetRequired": "需要选择资产",

--- a/src/assets/i18n/cn.json
+++ b/src/assets/i18n/cn.json
@@ -152,6 +152,7 @@
       "selectAsset": "选择资产",
       "sourceContract": "源合约",
       "destinationContract": "目标合约",
+      "amount": "数量",
       "procedureFee": "程序费用",
       "tick": "刻度",
       "tickOverwrite": "手动刻度覆盖",

--- a/src/assets/i18n/cn.json
+++ b/src/assets/i18n/cn.json
@@ -158,7 +158,7 @@
       "tickOverwrite": "手动刻度覆盖",
       "maxButton": "最大",
       "submit": "转移权利",
-      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
+      "revokeOnlyHint": "由 {{contract}} 管理的资产只能撤销到 QX"
     },
     "errors": {
       "assetRequired": "需要选择资产",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -157,7 +157,8 @@
       "tick": "Tick",
       "tickOverwrite": "Manuelles Tick-Override",
       "maxButton": "Max",
-      "submit": "Rechte übertragen"
+      "submit": "Rechte übertragen",
+      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
     },
     "errors": {
       "assetRequired": "Asset-Auswahl ist erforderlich",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -158,7 +158,7 @@
       "tickOverwrite": "Manuelles Tick-Override",
       "maxButton": "Max",
       "submit": "Rechte übertragen",
-      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
+      "revokeOnlyHint": "Von {{contract}} verwaltete Assets können nur an QX widerrufen werden"
     },
     "errors": {
       "assetRequired": "Asset-Auswahl ist erforderlich",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -152,6 +152,7 @@
       "selectAsset": "Asset auswählen",
       "sourceContract": "Quellvertrag",
       "destinationContract": "Zielvertrag",
+      "amount": "Menge",
       "procedureFee": "Verfahrensgebühr",
       "tick": "Tick",
       "tickOverwrite": "Manuelles Tick-Override",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -153,6 +153,7 @@
       "selectAsset": "Select Asset",
       "sourceContract": "Source Contract",
       "destinationContract": "Destination Contract",
+      "amount": "Amount",
       "balance": "Your balance after deducting transfer fees ({{fee}} Qubic) will be:",
       "tick": "Tick",
       "tickOverwrite": "Manual Tick Override",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -158,7 +158,8 @@
       "tick": "Tick",
       "tickOverwrite": "Manual Tick Override",
       "maxButton": "Max",
-      "submit": "Transfer Rights"
+      "submit": "Transfer Rights",
+      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
     },
     "errors": {
       "assetRequired": "Asset selection is required",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -152,6 +152,7 @@
       "selectAsset": "Seleccionar Activo",
       "sourceContract": "Contrato de Origen",
       "destinationContract": "Contrato de Destino",
+      "amount": "Cantidad",
       "procedureFee": "Tarifa del Procedimiento",
       "tick": "Tick",
       "tickOverwrite": "Anulación Manual de Tick",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -158,7 +158,7 @@
       "tickOverwrite": "Anulación Manual de Tick",
       "maxButton": "Máx",
       "submit": "Transferir Derechos",
-      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
+      "revokeOnlyHint": "Los activos gestionados por {{contract}} solo pueden ser revocados a QX"
     },
     "errors": {
       "assetRequired": "La selección de activo es obligatoria",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -157,7 +157,8 @@
       "tick": "Tick",
       "tickOverwrite": "Anulación Manual de Tick",
       "maxButton": "Máx",
-      "submit": "Transferir Derechos"
+      "submit": "Transferir Derechos",
+      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
     },
     "errors": {
       "assetRequired": "La selección de activo es obligatoria",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -157,7 +157,8 @@
       "tick": "Tick",
       "tickOverwrite": "Remplacement Manuel du Tick",
       "maxButton": "Max",
-      "submit": "Transférer les Droits"
+      "submit": "Transférer les Droits",
+      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
     },
     "errors": {
       "assetRequired": "La sélection d'actif est requise",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -152,6 +152,7 @@
       "selectAsset": "Sélectionner un Actif",
       "sourceContract": "Contrat Source",
       "destinationContract": "Contrat de Destination",
+      "amount": "Montant",
       "procedureFee": "Frais de Procédure",
       "tick": "Tick",
       "tickOverwrite": "Remplacement Manuel du Tick",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -158,7 +158,7 @@
       "tickOverwrite": "Remplacement Manuel du Tick",
       "maxButton": "Max",
       "submit": "Transférer les Droits",
-      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
+      "revokeOnlyHint": "Les actifs gérés par {{contract}} ne peuvent être révoqués que vers QX"
     },
     "errors": {
       "assetRequired": "La sélection d'actif est requise",

--- a/src/assets/i18n/jp.json
+++ b/src/assets/i18n/jp.json
@@ -157,7 +157,8 @@
       "tick": "ティック",
       "tickOverwrite": "手動ティックオーバーライド",
       "maxButton": "最大",
-      "submit": "権利を譲渡"
+      "submit": "権利を譲渡",
+      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
     },
     "errors": {
       "assetRequired": "資産の選択が必要です",

--- a/src/assets/i18n/jp.json
+++ b/src/assets/i18n/jp.json
@@ -158,7 +158,7 @@
       "tickOverwrite": "手動ティックオーバーライド",
       "maxButton": "最大",
       "submit": "権利を譲渡",
-      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
+      "revokeOnlyHint": "{{contract}} が管理するアセットは QX にのみ取り消すことができます"
     },
     "errors": {
       "assetRequired": "資産の選択が必要です",

--- a/src/assets/i18n/jp.json
+++ b/src/assets/i18n/jp.json
@@ -152,6 +152,7 @@
       "selectAsset": "資産を選択",
       "sourceContract": "ソース契約",
       "destinationContract": "宛先契約",
+      "amount": "数量",
       "procedureFee": "手続き手数料",
       "tick": "ティック",
       "tickOverwrite": "手動ティックオーバーライド",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -152,6 +152,7 @@
       "selectAsset": "Activa Selecteren",
       "sourceContract": "Broncontract",
       "destinationContract": "Bestemmingscontract",
+      "amount": "Aantal",
       "procedureFee": "Procedurekosten",
       "tick": "Tick",
       "tickOverwrite": "Handmatige Tick Overschrijving",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -157,7 +157,8 @@
       "tick": "Tick",
       "tickOverwrite": "Handmatige Tick Overschrijving",
       "maxButton": "Max",
-      "submit": "Rechten Overdragen"
+      "submit": "Rechten Overdragen",
+      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
     },
     "errors": {
       "assetRequired": "Activa selectie is verplicht",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -158,7 +158,7 @@
       "tickOverwrite": "Handmatige Tick Overschrijving",
       "maxButton": "Max",
       "submit": "Rechten Overdragen",
-      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
+      "revokeOnlyHint": "Assets beheerd door {{contract}} kunnen alleen worden ingetrokken naar QX"
     },
     "errors": {
       "assetRequired": "Activa selectie is verplicht",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -158,7 +158,7 @@
       "tickOverwrite": "Substituição Manual de Tick",
       "maxButton": "Máx",
       "submit": "Transferir Direitos",
-      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
+      "revokeOnlyHint": "Os assets gerenciados por {{contract}} só podem ser revogados para QX"
     },
     "errors": {
       "assetRequired": "A seleção de ativo é obrigatória",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -157,7 +157,8 @@
       "tick": "Tick",
       "tickOverwrite": "Substituição Manual de Tick",
       "maxButton": "Máx",
-      "submit": "Transferir Direitos"
+      "submit": "Transferir Direitos",
+      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
     },
     "errors": {
       "assetRequired": "A seleção de ativo é obrigatória",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -152,6 +152,7 @@
       "selectAsset": "Selecionar Ativo",
       "sourceContract": "Contrato de Origem",
       "destinationContract": "Contrato de Destino",
+      "amount": "Quantidade",
       "procedureFee": "Taxa de Procedimento",
       "tick": "Tick",
       "tickOverwrite": "Substituição Manual de Tick",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -152,6 +152,7 @@
       "selectAsset": "Выбрать Актив",
       "sourceContract": "Исходный Контракт",
       "destinationContract": "Целевой Контракт",
+      "amount": "Количество",
       "procedureFee": "Комиссия за Процедуру",
       "tick": "Тик",
       "tickOverwrite": "Ручная Замена Тика",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -157,7 +157,8 @@
       "tick": "Тик",
       "tickOverwrite": "Ручная Замена Тика",
       "maxButton": "Макс",
-      "submit": "Передать Права"
+      "submit": "Передать Права",
+      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
     },
     "errors": {
       "assetRequired": "Требуется выбор актива",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -158,7 +158,7 @@
       "tickOverwrite": "Ручная Замена Тика",
       "maxButton": "Макс",
       "submit": "Передать Права",
-      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
+      "revokeOnlyHint": "Активы, управляемые {{contract}}, могут быть отозваны только в QX"
     },
     "errors": {
       "assetRequired": "Требуется выбор актива",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -158,7 +158,7 @@
       "tickOverwrite": "Manuel Tick Geçersiz Kılma",
       "maxButton": "Maks",
       "submit": "Hakları Aktar",
-      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
+      "revokeOnlyHint": "{{contract}} tarafından yönetilen varlıklar yalnızca QX'e iptal edilebilir"
     },
     "errors": {
       "assetRequired": "Varlık seçimi gerekli",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -157,7 +157,8 @@
       "tick": "Tick",
       "tickOverwrite": "Manuel Tick Geçersiz Kılma",
       "maxButton": "Maks",
-      "submit": "Hakları Aktar"
+      "submit": "Hakları Aktar",
+      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
     },
     "errors": {
       "assetRequired": "Varlık seçimi gerekli",

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -152,6 +152,7 @@
       "selectAsset": "Varlık Seç",
       "sourceContract": "Kaynak Sözleşme",
       "destinationContract": "Hedef Sözleşme",
+      "amount": "Miktar",
       "procedureFee": "İşlem Ücreti",
       "tick": "Tick",
       "tickOverwrite": "Manuel Tick Geçersiz Kılma",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -157,7 +157,8 @@
       "tick": "Tick",
       "tickOverwrite": "Ghi đè Tick Thủ công",
       "maxButton": "Tối đa",
-      "submit": "Chuyển Quyền"
+      "submit": "Chuyển Quyền",
+      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
     },
     "errors": {
       "assetRequired": "Lựa chọn tài sản là bắt buộc",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -158,7 +158,7 @@
       "tickOverwrite": "Ghi đè Tick Thủ công",
       "maxButton": "Tối đa",
       "submit": "Chuyển Quyền",
-      "revokeOnlyHint": "Assets managed by {{contract}} can only be revoked to QX"
+      "revokeOnlyHint": "Tài sản được quản lý bởi {{contract}} chỉ có thể thu hồi về QX"
     },
     "errors": {
       "assetRequired": "Lựa chọn tài sản là bắt buộc",

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -152,6 +152,7 @@
       "selectAsset": "Chọn Tài sản",
       "sourceContract": "Hợp đồng Nguồn",
       "destinationContract": "Hợp đồng Đích",
+      "amount": "Số lượng",
       "procedureFee": "Phí Thủ tục",
       "tick": "Tick",
       "tickOverwrite": "Ghi đè Tick Thủ công",


### PR DESCRIPTION
## Summary
- Support both `TransferShareManagementRights` and `RevokeAssetManagementRights` procedures, matched via `sourceIdentifier` field
- When source contract implements revoke, destination is restricted to QX only
- When source contract implements transfer, destination shows contracts with `allowTransferShares` and a management rights procedure
- Add submit-time validation guard for destination/procedure type consistency
- Preserve form selections when wallet is unlocked mid-form
- Add missing `transferRights.form.amount` translation to all languages