### PR TITLE
fix: update IPO stats URL to auctions.qubic.tools

### DIFF
--- a/src/app/ipo/ipo.component.ts
+++ b/src/app/ipo/ipo.component.ts
@@ -106,7 +106,7 @@ export class IpoComponent implements OnInit, OnDestroy {
   }
 
   openStats(contractId: number) {
-    window.open(`https://ipo.qubic.tools/${contractId}`, "_blank");
+    window.open(`https://auctions.qubic.tools/${contractId}`, "_blank");
   }
 
   getTotalPrice(bids: IpoBid[]) {


### PR DESCRIPTION
## Summary
- Update the IPO stats button URL from `ipo.qubic.tools` to `auctions.qubic.tools`

## Test plan
- [ ] Open IPO page, click the stats button on any contract
- [ ] Verify it opens `https://auctions.qubic.tools/{contractId}` in a new tab