### PR TITLE
feat: add sign/verify message page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -15,6 +15,7 @@ import { PublicUnLockComponent } from './public/unlock/unlock.component';
 import { ImportVaultComponent } from './public/import/import.component';
 import { QearnComponent } from './qearn/qearn.component';
 import { SettingsSupportComponent } from './settings/support/support.component';
+import { SignMessageComponent } from './sign-message/sign-message.component';
 
 const routes: Routes = [
   {
@@ -81,6 +82,11 @@ const routes: Routes = [
   {
     path: 'assets-area/transfer-rights',
     component: TransferRightsComponent
+  },
+  {
+    path: 'sign-message',
+    component: SignMessageComponent,
+    canActivate: [walletReadyGuard]
   },
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -94,6 +94,7 @@ import { SeedFirstLinePipe, SeedSecondLinePipe } from './pipes/seed-display-line
 import { DateTimePipe } from './pipes/date-time.pipe';
 import { TransferRightsComponent } from './assets/transfer-rights/transfer-rights.component';
 import { SettingsSupportComponent } from './settings/support/support.component';
+import { SignMessageComponent } from './sign-message/sign-message.component';
 
 
 /** Http interceptor providers in outside-in order */
@@ -145,7 +146,8 @@ export const httpInterceptorProviders = [{ provide: HTTP_INTERCEPTORS, useClass:
     DateTimePipe,
     SeedSecondLinePipe,
     TransferRightsComponent,
-    SettingsSupportComponent
+    SettingsSupportComponent,
+    SignMessageComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/main/main.component.html
+++ b/src/app/main/main.component.html
@@ -241,6 +241,10 @@
         <mat-icon svgIcon="key_vertical"></mat-icon>
         <span>{{ t('seedOverviewComponent.table.actions.revealSeed') }}</span>
       </button>
+      <button *ngIf="!isOnlyWatch" mat-menu-item (click)="signMessage(publicId)">
+        <mat-icon>draw</mat-icon>
+        <span>{{ t('seedOverviewComponent.table.actions.signMessage') }}</span>
+      </button>
       <button mat-menu-item (click)="edit(publicId)">
         <mat-icon>edit</mat-icon>
         <span>{{ t('seedOverviewComponent.table.actions.editSeed') }}</span>

--- a/src/app/main/main.component.ts
+++ b/src/app/main/main.component.ts
@@ -311,6 +311,14 @@ export class MainComponent implements AfterViewInit, OnDestroy {
     });
   }
 
+  signMessage(publicId: string) {
+    this.router.navigate(['/', 'sign-message'], {
+      queryParams: {
+        publicId: publicId
+      }
+    });
+  }
+
   edit(publicId: string) {
     if (!this.walletService.privateKey) {
       const dialogRef = this.dialog.open(UnLockComponent, { restoreFocus: false });

--- a/src/app/navigation/navigation.component.html
+++ b/src/app/navigation/navigation.component.html
@@ -88,6 +88,8 @@
               class="icon-color-link icon">toll</mat-icon>{{ t('general.navigation.qearn') }}</a>
           <a mat-list-item routerLink="assets-area" (click)="checkMobileToggle()" [class.selected-nav]="isAssetsSelected"><mat-icon
               class="icon-color-link icon">category</mat-icon>{{ t("general.navigation.assets") }}</a>
+          <a mat-list-item routerLink="sign-message" (click)="checkMobileToggle()" [class.selected-nav]="isSignMessageSelected"><mat-icon
+              class="icon-color-link icon">draw</mat-icon>{{ t("general.navigation.signMessage") }}</a>
           <a mat-list-item routerLink="ipo" (click)="checkMobileToggle()" [class.selected-nav]="isIpoSelected"><mat-icon
               class="icon-color-link icon">multiline_chart</mat-icon>{{ t("general.navigation.ipo") }}<span *ngIf="activeIpoCount > 0" class="nav-badge">{{ activeIpoCount }}</span></a>
           <a mat-list-item routerLink="settings" (click)="checkMobileToggle()" [class.selected-nav]="isSettingsSelected"><mat-icon

--- a/src/app/navigation/navigation.component.ts
+++ b/src/app/navigation/navigation.component.ts
@@ -66,6 +66,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
   public isQearnSelected = false;
   public isAssetsSelected = false;
   public isIpoSelected = false;
+  public isSignMessageSelected = false;
   public isSupportSelected = false;
   public activeIpoCount = 0;
   private destroy$ = new Subject<void>();
@@ -98,6 +99,7 @@ export class NavigationComponent implements OnInit, OnDestroy {
         this.isBalanceSelected = currentUrl === '/balance';
         this.isAssetsSelected = currentUrl === '/assets-area';
         this.isIpoSelected = currentUrl === '/ipo';
+        this.isSignMessageSelected = currentUrl.startsWith('/sign-message');
         this.isSettingsSelected = currentUrl === '/settings';
         this.isSupportSelected = currentUrl === '/support';
 

--- a/src/app/sign-message/sign-message.component.html
+++ b/src/app/sign-message/sign-message.component.html
@@ -1,0 +1,104 @@
+<ng-container *transloco="let t">
+  <div class="content_container">
+    <h1>{{ t("signMessageComponent.title") }}</h1>
+    <mat-tab-group mat-stretch-tabs="false" mat-align-tabs="start">
+
+      <!-- Sign Tab -->
+      <mat-tab label="{{ t('signMessageComponent.tabs.sign') }}">
+        <form [formGroup]="signForm" novalidate (ngSubmit)="onSign()">
+          <mat-card class="sign-card">
+            <mat-card-content>
+              <div class="row">
+                <div class="col">
+                  <mat-form-field appearance="fill" class="full-width">
+                    <mat-label>{{ t("signMessageComponent.form.sourceAccount") }}</mat-label>
+                    <mat-select formControlName="sourceId" panelClass="full-width">
+                      <mat-select-trigger>
+                        <span *ngIf="signForm.controls['sourceId'].value && getSelectedSourceSeed()">
+                          {{ getSelectedSourceSeed() | seedDisplay: { compact: true, currencyLabel: t('general.currency') } }}
+                        </span>
+                      </mat-select-trigger>
+                      <mat-option *ngFor="let seed of getSeeds()" [value]="seed.publicId" class="custom-mat-option">
+                        {{ seed | seedFirstLine }}<br />{{ seed | seedSecondLine: t('general.currency') }}
+                      </mat-option>
+                    </mat-select>
+                    <mat-error *ngIf="signForm.controls['sourceId'].hasError('required')">
+                      {{ t("signMessageComponent.messages.accountRequired") }}
+                    </mat-error>
+                  </mat-form-field>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col">
+                  <mat-form-field appearance="fill" class="full-width">
+                    <mat-label>{{ t("signMessageComponent.form.message") }}</mat-label>
+                    <textarea matInput formControlName="message" rows="3"
+                      [placeholder]="t('signMessageComponent.form.messagePlaceholder')"></textarea>
+                  </mat-form-field>
+                </div>
+              </div>
+              <div class="row" *ngIf="signOutput">
+                <div class="col output-wrapper">
+                  <button mat-icon-button class="copy-btn" matTooltip="{{ t('general.copy.tooltip') }}"
+                    [cdkCopyToClipboard]="signOutput" type="button">
+                    <mat-icon>content_copy</mat-icon>
+                  </button>
+                  <mat-form-field appearance="fill" class="full-width">
+                    <mat-label>{{ t("signMessageComponent.form.output") }}</mat-label>
+                    <textarea matInput [value]="signOutput" readonly rows="6"></textarea>
+                  </mat-form-field>
+                </div>
+              </div>
+            </mat-card-content>
+            <mat-card-actions class="padding">
+              <div *ngIf="!walletService.privateKey">
+                <button mat-raised-button color="primary" type="button" (click)="loadKey()">
+                  {{ t("paymentComponent.buttons.loadPrivateKey") }}
+                </button>
+              </div>
+              <button *ngIf="walletService.privateKey" mat-raised-button color="primary" type="submit"
+                [disabled]="!signForm.valid || isSigning">
+                <span *ngIf="!isSigning">{{ t("signMessageComponent.buttons.sign") }}</span>
+                <mat-progress-spinner mode="indeterminate" [diameter]="20" *ngIf="isSigning"></mat-progress-spinner>
+              </button>
+            </mat-card-actions>
+          </mat-card>
+        </form>
+      </mat-tab>
+
+      <!-- Verify Tab -->
+      <mat-tab label="{{ t('signMessageComponent.tabs.verify') }}">
+        <form [formGroup]="verifyForm" novalidate (ngSubmit)="onVerify()">
+          <mat-card class="sign-card">
+            <mat-card-content>
+              <div class="row">
+                <div class="col">
+                  <mat-form-field appearance="fill" class="full-width">
+                    <mat-label>{{ t("signMessageComponent.form.verifyInput") }}</mat-label>
+                    <textarea matInput formControlName="verifyInput" rows="6"
+                      [placeholder]="t('signMessageComponent.form.verifyInputPlaceholder')"></textarea>
+                  </mat-form-field>
+                </div>
+              </div>
+              <div *ngIf="verifyResult === 'valid'" class="verify-result valid">
+                {{ t("signMessageComponent.result.valid") }}
+              </div>
+              <div *ngIf="verifyResult === 'invalid'" class="verify-result invalid">
+                {{ t("signMessageComponent.result.invalid") }}
+              </div>
+              <div *ngIf="verifyError" class="verify-error">
+                {{ verifyError }}
+              </div>
+            </mat-card-content>
+            <mat-card-actions class="padding">
+              <button mat-raised-button color="primary" type="submit" [disabled]="!verifyForm.valid">
+                {{ t("signMessageComponent.buttons.verify") }}
+              </button>
+            </mat-card-actions>
+          </mat-card>
+        </form>
+      </mat-tab>
+
+    </mat-tab-group>
+  </div>
+</ng-container>

--- a/src/app/sign-message/sign-message.component.scss
+++ b/src/app/sign-message/sign-message.component.scss
@@ -1,0 +1,64 @@
+@import "../../vars.scss";
+
+.full-width {
+  width: 100%;
+}
+
+.sign-card {
+  min-width: 120px;
+  margin: 20px auto;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.col {
+  flex: 1;
+  margin-right: 20px;
+  margin-bottom: 15px;
+}
+
+.col:last-child {
+  margin-right: 0;
+}
+
+.padding button {
+  margin: 10px;
+}
+
+.output-wrapper {
+  position: relative;
+
+  ::ng-deep .copy-btn {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    z-index: 1;
+  }
+}
+
+.verify-result {
+  padding: 12px;
+  border-radius: 4px;
+  text-align: center;
+  font-weight: bold;
+  margin: 8px 0;
+
+  &.valid {
+    background-color: rgba($trx-success-color, 0.2);
+    color: $trx-success-color;
+  }
+
+  &.invalid {
+    background-color: rgba($trx-failure-color, 0.2);
+    color: $trx-failure-color;
+  }
+}
+
+.verify-error {
+  color: $trx-failure-color;
+  margin: 8px 0;
+}

--- a/src/app/sign-message/sign-message.component.ts
+++ b/src/app/sign-message/sign-message.component.ts
@@ -1,0 +1,231 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { FormBuilder, Validators } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { TranslocoService } from '@ngneat/transloco';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { WalletService } from '../services/wallet.service';
+import { UnLockComponent } from '../lock/unlock/unlock.component';
+import Crypto from '@qubic-lib/qubic-ts-library/dist/crypto';
+import { QubicHelper } from '@qubic-lib/qubic-ts-library/dist/qubicHelper';
+import { KeyHelper } from '@qubic-lib/qubic-ts-library/dist/keyHelper';
+
+@Component({
+  selector: 'app-sign-message',
+  templateUrl: './sign-message.component.html',
+  styleUrls: ['./sign-message.component.scss']
+})
+export class SignMessageComponent implements OnInit, OnDestroy {
+
+  private destroy$ = new Subject<void>();
+
+  signForm = this.fb.group({
+    sourceId: ['', [Validators.required]],
+    message: ['', [Validators.required]],
+  });
+
+  verifyForm = this.fb.group({
+    verifyInput: ['', [Validators.required]],
+  });
+
+  signOutput = '';
+  isSigning = false;
+
+  verifyResult: 'valid' | 'invalid' | null = null;
+  verifyError = '';
+
+  constructor(
+    private t: TranslocoService,
+    private fb: FormBuilder,
+    private route: ActivatedRoute,
+    private _snackBar: MatSnackBar,
+    public walletService: WalletService,
+    private dialog: MatDialog,
+  ) {}
+
+  ngOnInit(): void {
+    this.route.queryParams
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(params => {
+        if (params['publicId']) {
+          this.signForm.controls.sourceId.setValue(params['publicId']);
+        }
+      });
+
+    this.signForm.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.signOutput = '';
+      });
+
+    this.verifyForm.controls.verifyInput.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.verifyResult = null;
+        this.verifyError = '';
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  getSeeds() {
+    return this.walletService.getSeeds().filter(f => !f.isOnlyWatch);
+  }
+
+  getSelectedSourceSeed() {
+    const publicId = this.signForm.controls.sourceId.value;
+    return this.getSeeds().find(s => s.publicId === publicId);
+  }
+
+  loadKey() {
+    this.dialog.open(UnLockComponent, { restoreFocus: false });
+  }
+
+  async onSign() {
+    if (!this.walletService.privateKey) {
+      const dialogRef = this.dialog.open(UnLockComponent, { restoreFocus: false });
+      dialogRef.afterClosed().subscribe(() => {
+        if (this.walletService.privateKey) {
+          this.onSign();
+        }
+      });
+      return;
+    }
+
+    const sourceId = this.signForm.controls.sourceId.value;
+    const message = this.signForm.controls.message.value;
+    if (!sourceId || !message) return;
+
+    this.isSigning = true;
+    this.signOutput = '';
+
+    try {
+      const seed = await this.walletService.revealSeed(sourceId);
+      const { schnorrq, K12 } = await Crypto;
+      const helper = new QubicHelper();
+      const idPackage = await helper.createIdPackage(seed);
+
+      const messageBytes = new TextEncoder().encode(message);
+      const signature = schnorrq.sign(idPackage.privateKey, idPackage.publicKey, messageBytes);
+
+      const checksumOut = new Uint8Array(1);
+      K12(signature, checksumOut, 1);
+
+      const sigWithChecksum = new Uint8Array(65);
+      sigWithChecksum.set(signature);
+      sigWithChecksum[64] = checksumOut[0];
+
+      const result = {
+        identity: idPackage.publicId,
+        message: message,
+        signature: this.encodeShiftedHex(sigWithChecksum),
+      };
+
+      this.signOutput = JSON.stringify(result, null, 2);
+    } catch (e) {
+      this._snackBar.open(
+        this.t.translate('signMessageComponent.messages.signError'),
+        this.t.translate('general.close'),
+        { duration: 5000, panelClass: 'error' }
+      );
+    } finally {
+      this.isSigning = false;
+    }
+  }
+
+  async onVerify() {
+    this.verifyResult = null;
+    this.verifyError = '';
+
+    const input = this.verifyForm.controls.verifyInput.value;
+    if (!input) return;
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(input);
+    } catch {
+      this.verifyError = this.t.translate('signMessageComponent.messages.parseError');
+      return;
+    }
+
+    const { identity, message, signature } = parsed;
+    if (!identity || !message || !signature) {
+      this.verifyError = this.t.translate('signMessageComponent.messages.parseError');
+      return;
+    }
+
+    if (!/^[A-Z]{60}$/.test(identity)) {
+      this.verifyError = this.t.translate('signMessageComponent.messages.invalidIdentity');
+      return;
+    }
+
+    const helper = new QubicHelper();
+    if (!(await helper.verifyIdentity(identity))) {
+      this.verifyError = this.t.translate('signMessageComponent.messages.invalidIdentity');
+      return;
+    }
+
+    if (!/^[A-Pa-p]{130}$/.test(signature)) {
+      this.verifyError = this.t.translate('signMessageComponent.messages.invalidSignature');
+      return;
+    }
+
+    try {
+      const decoded = this.decodeShiftedHex(signature);
+      if (decoded.length !== 65) {
+        this.verifyError = this.t.translate('signMessageComponent.messages.invalidSignature');
+        return;
+      }
+
+      const sigBytes = decoded.slice(0, 64);
+      const checksum = decoded[64];
+
+      const { schnorrq, K12 } = await Crypto;
+
+      const checksumOut = new Uint8Array(1);
+      K12(sigBytes, checksumOut, 1);
+      if (checksumOut[0] !== checksum) {
+        this.verifyError = this.t.translate('signMessageComponent.messages.checksumMismatch');
+        return;
+      }
+
+      const publicKeyBytes = KeyHelper.getIdentityBytes(identity);
+      const messageBytes = new TextEncoder().encode(message);
+      const result = schnorrq.verify(publicKeyBytes, messageBytes, sigBytes);
+
+      this.verifyResult = result === 1 ? 'valid' : 'invalid';
+    } catch {
+      this.verifyError = this.t.translate('signMessageComponent.messages.signError');
+    }
+  }
+
+  private encodeShiftedHex(bytes: Uint8Array): string {
+    let result = '';
+    const A = 'A'.charCodeAt(0);
+    for (let i = 0; i < bytes.length; i++) {
+      result += String.fromCharCode(A + (bytes[i] >> 4));
+      result += String.fromCharCode(A + (bytes[i] & 0x0F));
+    }
+    return result;
+  }
+
+  private decodeShiftedHex(str: string): Uint8Array {
+    const upper = str.toUpperCase();
+    const A = 'A'.charCodeAt(0);
+    const bytes = new Uint8Array(upper.length / 2);
+    for (let i = 0; i < bytes.length; i++) {
+      const hi = upper.charCodeAt(i * 2) - A;
+      const lo = upper.charCodeAt(i * 2 + 1) - A;
+      if (hi < 0 || hi > 15 || lo < 0 || lo > 15) {
+        throw new Error('Invalid shifted hex character');
+      }
+      bytes[i] = (hi << 4) | lo;
+    }
+    return bytes;
+  }
+}

--- a/src/app/sign-message/sign-message.component.ts
+++ b/src/app/sign-message/sign-message.component.ts
@@ -11,6 +11,7 @@ import { UnLockComponent } from '../lock/unlock/unlock.component';
 import Crypto from '@qubic-lib/qubic-ts-library/dist/crypto';
 import { QubicHelper } from '@qubic-lib/qubic-ts-library/dist/qubicHelper';
 import { KeyHelper } from '@qubic-lib/qubic-ts-library/dist/keyHelper';
+import { encodeShiftedHex, decodeShiftedHex } from '../utils/shifted-hex.utils';
 
 @Component({
   selector: 'app-sign-message',
@@ -123,7 +124,7 @@ export class SignMessageComponent implements OnInit, OnDestroy {
       const result = {
         identity: idPackage.publicId,
         message: message,
-        signature: this.encodeShiftedHex(sigWithChecksum),
+        signature: encodeShiftedHex(sigWithChecksum),
       };
 
       this.signOutput = JSON.stringify(result, null, 2);
@@ -176,7 +177,7 @@ export class SignMessageComponent implements OnInit, OnDestroy {
     }
 
     try {
-      const decoded = this.decodeShiftedHex(signature);
+      const decoded = decodeShiftedHex(signature);
       if (decoded.length !== 65) {
         this.verifyError = this.t.translate('signMessageComponent.messages.invalidSignature');
         return;
@@ -204,28 +205,4 @@ export class SignMessageComponent implements OnInit, OnDestroy {
     }
   }
 
-  private encodeShiftedHex(bytes: Uint8Array): string {
-    let result = '';
-    const A = 'A'.charCodeAt(0);
-    for (let i = 0; i < bytes.length; i++) {
-      result += String.fromCharCode(A + (bytes[i] >> 4));
-      result += String.fromCharCode(A + (bytes[i] & 0x0F));
-    }
-    return result;
-  }
-
-  private decodeShiftedHex(str: string): Uint8Array {
-    const upper = str.toUpperCase();
-    const A = 'A'.charCodeAt(0);
-    const bytes = new Uint8Array(upper.length / 2);
-    for (let i = 0; i < bytes.length; i++) {
-      const hi = upper.charCodeAt(i * 2) - A;
-      const lo = upper.charCodeAt(i * 2 + 1) - A;
-      if (hi < 0 || hi > 15 || lo < 0 || lo > 15) {
-        throw new Error('Invalid shifted hex character');
-      }
-      bytes[i] = (hi << 4) | lo;
-    }
-    return bytes;
-  }
 }

--- a/src/app/utils/shifted-hex.utils.ts
+++ b/src/app/utils/shifted-hex.utils.ts
@@ -1,0 +1,42 @@
+/**
+ * Encodes a byte array as "shifted hex" using the A-P alphabet where each
+ * byte is represented by 2 uppercase characters (A=0, B=1, ..., P=15).
+ *
+ * This encoding is used by the Qubic.NET Wallet and Toolkit for message
+ * signatures.
+ *
+ * @param bytes The byte array to encode
+ * @returns The shifted hex string (2 chars per input byte)
+ */
+export function encodeShiftedHex(bytes: Uint8Array): string {
+  let result = '';
+  const A = 'A'.charCodeAt(0);
+  for (let i = 0; i < bytes.length; i++) {
+    result += String.fromCharCode(A + (bytes[i] >> 4));
+    result += String.fromCharCode(A + (bytes[i] & 0x0F));
+  }
+  return result;
+}
+
+/**
+ * Decodes a "shifted hex" string (A-P alphabet) back into a byte array.
+ * Accepts both uppercase and lowercase input.
+ *
+ * @param str The shifted hex string (must have even length, chars A-P / a-p)
+ * @returns The decoded byte array (length = str.length / 2)
+ * @throws Error if the string contains characters outside the A-P / a-p range
+ */
+export function decodeShiftedHex(str: string): Uint8Array {
+  const upper = str.toUpperCase();
+  const A = 'A'.charCodeAt(0);
+  const bytes = new Uint8Array(upper.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    const hi = upper.charCodeAt(i * 2) - A;
+    const lo = upper.charCodeAt(i * 2 + 1) - A;
+    if (hi < 0 || hi > 15 || lo < 0 || lo > 15) {
+      throw new Error('Invalid shifted hex character');
+    }
+    bytes[i] = (hi << 4) | lo;
+  }
+  return bytes;
+}

--- a/src/assets/i18n/cn.json
+++ b/src/assets/i18n/cn.json
@@ -11,7 +11,8 @@
       "settings": "设置",
       "ipo": "IPO",
       "assets": "资产",
-      "support": "支援"
+      "support": "支援",
+      "signMessage": "签名消息"
     },
     "version": "Version {{version}}",
     "version.url": "qubic.org",
@@ -260,7 +261,8 @@
         "editSeed": "编辑地址",
         "deleteSeed": "删除地址",
         "refreshBalance": "刷新余额",
-        "openExplorer": "在浏览器中查看"
+        "openExplorer": "在浏览器中查看",
+        "signMessage": "签署消息"
       }
     },
     "hasPendingTransaction": "交易待定",
@@ -687,6 +689,37 @@
       "rewardTable": "奖励表",
       "txSuccess": "交易成功！",
       "txFailed": "交易失败！"
+    }
+  },
+  "signMessageComponent": {
+    "title": "签名 / 验证消息",
+    "tabs": {
+      "sign": "签名消息",
+      "verify": "验证消息"
+    },
+    "form": {
+      "sourceAccount": "用于签名的账户",
+      "message": "消息",
+      "messagePlaceholder": "输入要签名的消息",
+      "output": "签名输出 (JSON)",
+      "verifyInput": "已签名消息 (JSON)",
+      "verifyInputPlaceholder": "粘贴包含 identity、message 和 signature 字段的 JSON"
+    },
+    "buttons": {
+      "sign": "签名消息",
+      "verify": "验证签名"
+    },
+    "result": {
+      "valid": "签名有效",
+      "invalid": "签名无效"
+    },
+    "messages": {
+      "signError": "签名消息失败。请重试。",
+      "parseError": "无效的 JSON 格式。预期: { identity, message, signature }",
+      "invalidIdentity": "无效的身份格式。预期 60 个大写字母 A-Z。",
+      "invalidSignature": "无效的签名格式。预期 130 个 A-P 字符。",
+      "checksumMismatch": "签名校验和验证失败。",
+      "accountRequired": "请选择一个账户"
     }
   }
 }

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -11,7 +11,8 @@
       "settings": "Einstellungen",
       "ipo": "IPO",
       "assets": "Assets",
-      "support": "Unterstützung"
+      "support": "Unterstützung",
+      "signMessage": "Nachricht signieren"
     },
     "version": "Version {{version}}",
     "version.url": "qubic.org",
@@ -260,7 +261,8 @@
         "editSeed": "Konto bearbeiten",
         "deleteSeed": "Konto löschen",
         "refreshBalance": "Kontostand im Netzwerk abrufen",
-        "openExplorer": "In Explorer anzeigen"
+        "openExplorer": "In Explorer anzeigen",
+        "signMessage": "Nachricht signieren"
       }
     },
     "hasPendingTransaction": "Offene Zahlungen",
@@ -687,6 +689,37 @@
       "rewardTable": "Belohnungstabelle",
       "txSuccess": "Transaktion erfolgreich!",
       "txFailed": "Transaktion fehlgeschlagen!"
+    }
+  },
+  "signMessageComponent": {
+    "title": "Nachricht signieren / verifizieren",
+    "tabs": {
+      "sign": "Nachricht signieren",
+      "verify": "Nachricht verifizieren"
+    },
+    "form": {
+      "sourceAccount": "Konto zum Signieren",
+      "message": "Nachricht",
+      "messagePlaceholder": "Nachricht zum Signieren eingeben",
+      "output": "Signierte Ausgabe (JSON)",
+      "verifyInput": "Signierte Nachricht (JSON)",
+      "verifyInputPlaceholder": "JSON mit identity, message und signature Feldern einfügen"
+    },
+    "buttons": {
+      "sign": "Nachricht signieren",
+      "verify": "Signatur verifizieren"
+    },
+    "result": {
+      "valid": "Gültige Signatur",
+      "invalid": "Ungültige Signatur"
+    },
+    "messages": {
+      "signError": "Nachricht konnte nicht signiert werden. Bitte versuchen Sie es erneut.",
+      "parseError": "Ungültiges JSON-Format. Erwartet: { identity, message, signature }",
+      "invalidIdentity": "Ungültiges Identitätsformat. Erwartet 60 Großbuchstaben A-Z.",
+      "invalidSignature": "Ungültiges Signaturformat. Erwartet 130 A-P Zeichen.",
+      "checksumMismatch": "Signatur-Prüfsummenverifizierung fehlgeschlagen.",
+      "accountRequired": "Bitte wählen Sie ein Konto aus"
     }
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -11,7 +11,8 @@
       "settings": "Settings",
       "ipo": "IPO",
       "assets": "Assets",
-      "support": "Support"
+      "support": "Support",
+      "signMessage": "Sign Message"
     },
     "version": "Version {{version}}",
     "version.url": "qubic.org",
@@ -262,7 +263,8 @@
         "editSeed": "Edit address",
         "deleteSeed": "Delete address",
         "refreshBalance": "Refresh Balance from Network",
-        "openExplorer": "View in Explorer"
+        "openExplorer": "View in Explorer",
+        "signMessage": "Sign a message"
       }
     },
     "hasPendingTransaction": "Transactions pending",
@@ -690,6 +692,37 @@
       "rewardTable": "Reward Table",
       "txSuccess": "Transaction Succeeded!",
       "txFailed": "Transaction Failed!"
+    }
+  },
+  "signMessageComponent": {
+    "title": "Sign / Verify Message",
+    "tabs": {
+      "sign": "Sign Message",
+      "verify": "Verify Message"
+    },
+    "form": {
+      "sourceAccount": "Account to sign with",
+      "message": "Message",
+      "messagePlaceholder": "Enter message to sign",
+      "output": "Signed output (JSON)",
+      "verifyInput": "Signed message (JSON)",
+      "verifyInputPlaceholder": "Paste JSON with identity, message, and signature fields"
+    },
+    "buttons": {
+      "sign": "Sign Message",
+      "verify": "Verify Signature"
+    },
+    "result": {
+      "valid": "Valid Signature",
+      "invalid": "Invalid Signature"
+    },
+    "messages": {
+      "signError": "Failed to sign message. Please try again.",
+      "parseError": "Invalid JSON format. Expected: { identity, message, signature }",
+      "invalidIdentity": "Invalid identity format. Expected 60 uppercase A-Z characters.",
+      "invalidSignature": "Invalid signature format. Expected 130 A-P characters.",
+      "checksumMismatch": "Signature checksum verification failed.",
+      "accountRequired": "Please select an account"
     }
   }
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -11,7 +11,8 @@
       "settings": "Configuraciones",
       "ipo": "IPO",
       "assets": "Assets",
-      "support": "Soporte"
+      "support": "Soporte",
+      "signMessage": "Firmar Mensaje"
     },
     "version": "Versión {{version}}",
     "version.url": "qubic.org",
@@ -260,7 +261,8 @@
         "editSeed": "Editar la dirección",
         "deleteSeed": "Eliminar la dirección",
         "refreshBalance": "Actualizar el saldo desde la red",
-        "openExplorer": "Ver en el Explorador"
+        "openExplorer": "Ver en el Explorador",
+        "signMessage": "Firmar un mensaje"
       }
     },
     "hasPendingTransaction": "Transacciones pendientes",
@@ -685,6 +687,37 @@
       "rewardTable": "Tabla de recompensas",
       "txSuccess": "Transacción exitosa!",
       "txFailed": "Transacción fallida!"
+    }
+  },
+  "signMessageComponent": {
+    "title": "Firmar / Verificar Mensaje",
+    "tabs": {
+      "sign": "Firmar Mensaje",
+      "verify": "Verificar Mensaje"
+    },
+    "form": {
+      "sourceAccount": "Cuenta para firmar",
+      "message": "Mensaje",
+      "messagePlaceholder": "Ingrese el mensaje a firmar",
+      "output": "Salida firmada (JSON)",
+      "verifyInput": "Mensaje firmado (JSON)",
+      "verifyInputPlaceholder": "Pegue JSON con los campos identity, message y signature"
+    },
+    "buttons": {
+      "sign": "Firmar Mensaje",
+      "verify": "Verificar Firma"
+    },
+    "result": {
+      "valid": "Firma Válida",
+      "invalid": "Firma Inválida"
+    },
+    "messages": {
+      "signError": "Error al firmar el mensaje. Por favor, inténtelo de nuevo.",
+      "parseError": "Formato JSON inválido. Esperado: { identity, message, signature }",
+      "invalidIdentity": "Formato de identidad inválido. Se esperan 60 caracteres A-Z en mayúsculas.",
+      "invalidSignature": "Formato de firma inválido. Se esperan 130 caracteres A-P.",
+      "checksumMismatch": "La verificación de la suma de comprobación de la firma falló.",
+      "accountRequired": "Por favor, seleccione una cuenta"
     }
   }
 }

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -11,7 +11,8 @@
       "settings": "Paramètres",
       "ipo": "IPO",
       "assets": "Actifs",
-      "support": "Support"
+      "support": "Support",
+      "signMessage": "Signer un Message"
     },
     "version": "Version {{version}}",
     "version.url": "qubic.org",
@@ -260,7 +261,8 @@
         "editSeed": "Modifier l'adresse",
         "deleteSeed": "Supprimer l'adresse",
         "refreshBalance": "Actualiser le solde depuis le réseau",
-        "openExplorer": "Afficher dans l'Explorateur"
+        "openExplorer": "Afficher dans l'Explorateur",
+        "signMessage": "Signer un message"
       }
     },
     "hasPendingTransaction": "Transactions en attente",
@@ -685,6 +687,37 @@
       "rewardTable": "Tableau des récompenses",
       "txSuccess": "Transaction réussie!",
       "txFailed": "Échec de la transaction!"
+    }
+  },
+  "signMessageComponent": {
+    "title": "Signer / Vérifier un Message",
+    "tabs": {
+      "sign": "Signer un Message",
+      "verify": "Vérifier un Message"
+    },
+    "form": {
+      "sourceAccount": "Compte pour signer",
+      "message": "Message",
+      "messagePlaceholder": "Entrez le message à signer",
+      "output": "Sortie signée (JSON)",
+      "verifyInput": "Message signé (JSON)",
+      "verifyInputPlaceholder": "Collez le JSON avec les champs identity, message et signature"
+    },
+    "buttons": {
+      "sign": "Signer le Message",
+      "verify": "Vérifier la Signature"
+    },
+    "result": {
+      "valid": "Signature Valide",
+      "invalid": "Signature Invalide"
+    },
+    "messages": {
+      "signError": "Échec de la signature du message. Veuillez réessayer.",
+      "parseError": "Format JSON invalide. Attendu : { identity, message, signature }",
+      "invalidIdentity": "Format d'identité invalide. 60 caractères majuscules A-Z attendus.",
+      "invalidSignature": "Format de signature invalide. 130 caractères A-P attendus.",
+      "checksumMismatch": "La vérification de la somme de contrôle de la signature a échoué.",
+      "accountRequired": "Veuillez sélectionner un compte"
     }
   }
 }

--- a/src/assets/i18n/jp.json
+++ b/src/assets/i18n/jp.json
@@ -11,7 +11,8 @@
       "settings": "設定",
       "ipo": "IPO",
       "assets": "資産",
-      "support": "Support"
+      "support": "Support",
+      "signMessage": "メッセージ署名"
     },
     "version": "バージョン {{version}}",
     "version.url": "qubic.org",
@@ -260,7 +261,8 @@
         "editSeed": "アドレスを編集",
         "deleteSeed": "アドレスを削除",
         "refreshBalance": "ネットワークから残高を更新",
-        "openExplorer": "エクスプローラーで表示"
+        "openExplorer": "エクスプローラーで表示",
+        "signMessage": "メッセージに署名"
       }
     },
     "hasPendingTransaction": "保留中の取引",
@@ -688,6 +690,37 @@
       "rewardTable": "報酬表",
       "txSuccess": "取引が成功しました！",
       "txFailed": "取引に失敗しました！"
+    }
+  },
+  "signMessageComponent": {
+    "title": "メッセージの署名 / 検証",
+    "tabs": {
+      "sign": "メッセージ署名",
+      "verify": "メッセージ検証"
+    },
+    "form": {
+      "sourceAccount": "署名に使用するアカウント",
+      "message": "メッセージ",
+      "messagePlaceholder": "署名するメッセージを入力",
+      "output": "署名済み出力 (JSON)",
+      "verifyInput": "署名済みメッセージ (JSON)",
+      "verifyInputPlaceholder": "identity、message、signature フィールドを含む JSON を貼り付け"
+    },
+    "buttons": {
+      "sign": "メッセージ署名",
+      "verify": "署名を検証"
+    },
+    "result": {
+      "valid": "有効な署名",
+      "invalid": "無効な署名"
+    },
+    "messages": {
+      "signError": "メッセージの署名に失敗しました。もう一度お試しください。",
+      "parseError": "無効な JSON 形式です。期待: { identity, message, signature }",
+      "invalidIdentity": "無効な ID 形式です。大文字 A-Z 60 文字が必要です。",
+      "invalidSignature": "無効な署名形式です。A-P 130 文字が必要です。",
+      "checksumMismatch": "署名チェックサムの検証に失敗しました。",
+      "accountRequired": "アカウントを選択してください"
     }
   }
 }

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -11,7 +11,8 @@
       "settings": "Instellingen",
       "ipo": "IPO",
       "assets": "Assets",
-      "support": "Ondersteuning"
+      "support": "Ondersteuning",
+      "signMessage": "Bericht Ondertekenen"
     },
     "version": "Versie {{version}}",
     "version.url": "qubic.org",
@@ -260,7 +261,8 @@
         "editSeed": "Account aanpassen",
         "deleteSeed": "Account verwijderen",
         "refreshBalance": "Refresh Balance from Network",
-        "openExplorer": "Weergeven in Explorer"
+        "openExplorer": "Weergeven in Explorer",
+        "signMessage": "Een bericht ondertekenen"
       }
     },
     "hasPendingTransaction": "Transactions pending",
@@ -685,6 +687,37 @@
       "rewardTable": "Beloningstabel",
       "txSuccess": "Transactie geslaagd!",
       "txFailed": "Transactie mislukt!"
+    }
+  },
+  "signMessageComponent": {
+    "title": "Bericht Ondertekenen / Verifiëren",
+    "tabs": {
+      "sign": "Bericht Ondertekenen",
+      "verify": "Bericht Verifiëren"
+    },
+    "form": {
+      "sourceAccount": "Account om mee te ondertekenen",
+      "message": "Bericht",
+      "messagePlaceholder": "Voer het te ondertekenen bericht in",
+      "output": "Ondertekende uitvoer (JSON)",
+      "verifyInput": "Ondertekend bericht (JSON)",
+      "verifyInputPlaceholder": "Plak JSON met identity, message en signature velden"
+    },
+    "buttons": {
+      "sign": "Bericht Ondertekenen",
+      "verify": "Handtekening Verifiëren"
+    },
+    "result": {
+      "valid": "Geldige Handtekening",
+      "invalid": "Ongeldige Handtekening"
+    },
+    "messages": {
+      "signError": "Kan bericht niet ondertekenen. Probeer het opnieuw.",
+      "parseError": "Ongeldig JSON-formaat. Verwacht: { identity, message, signature }",
+      "invalidIdentity": "Ongeldig identiteitsformaat. Verwacht 60 hoofdletters A-Z.",
+      "invalidSignature": "Ongeldig handtekeningformaat. Verwacht 130 A-P tekens.",
+      "checksumMismatch": "Verificatie van de handtekeningcontrolesom is mislukt.",
+      "accountRequired": "Selecteer een account"
     }
   }
 }

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -11,7 +11,8 @@
       "settings": "Configurações",
       "ipo": "IPO",
       "assets": "Assets",
-      "support": "Suporte"
+      "support": "Suporte",
+      "signMessage": "Assinar Mensagem"
     },
     "version": "Versão {{version}}",
     "version.url": "qubic.org",
@@ -260,7 +261,8 @@
         "editSeed": "Editar endereço",
         "deleteSeed": "Excluir endereço",
         "refreshBalance": "Atualizar saldo da rede",
-        "openExplorer": "Ver no Explorador"
+        "openExplorer": "Ver no Explorador",
+        "signMessage": "Assinar uma mensagem"
       }
     },
     "hasPendingTransaction": "Transações pendentes",
@@ -684,6 +686,37 @@
       "rewardTable": "Tabela de recompensas",
       "txSuccess": "Transação bem-sucedida!",
       "txFailed": "Falha na transação!"
+    }
+  },
+  "signMessageComponent": {
+    "title": "Assinar / Verificar Mensagem",
+    "tabs": {
+      "sign": "Assinar Mensagem",
+      "verify": "Verificar Mensagem"
+    },
+    "form": {
+      "sourceAccount": "Conta para assinar",
+      "message": "Mensagem",
+      "messagePlaceholder": "Digite a mensagem para assinar",
+      "output": "Saída assinada (JSON)",
+      "verifyInput": "Mensagem assinada (JSON)",
+      "verifyInputPlaceholder": "Cole o JSON com os campos identity, message e signature"
+    },
+    "buttons": {
+      "sign": "Assinar Mensagem",
+      "verify": "Verificar Assinatura"
+    },
+    "result": {
+      "valid": "Assinatura Válida",
+      "invalid": "Assinatura Inválida"
+    },
+    "messages": {
+      "signError": "Falha ao assinar a mensagem. Por favor, tente novamente.",
+      "parseError": "Formato JSON inválido. Esperado: { identity, message, signature }",
+      "invalidIdentity": "Formato de identidade inválido. Esperados 60 caracteres maiúsculos A-Z.",
+      "invalidSignature": "Formato de assinatura inválido. Esperados 130 caracteres A-P.",
+      "checksumMismatch": "Falha na verificação da soma de verificação da assinatura.",
+      "accountRequired": "Por favor, selecione uma conta"
     }
   }
 }

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -11,7 +11,8 @@
       "settings": "Настройки",
       "ipo": "IPO",
       "assets": "Акции",
-      "support": "Поддержка"
+      "support": "Поддержка",
+      "signMessage": "Подписать Сообщение"
     },
     "version": "Версия {{version}}",
     "version.url": "qubic.org",
@@ -260,7 +261,8 @@
         "editSeed": "Редактировать счет",
         "deleteSeed": "Удалить аккаунт",
         "refreshBalance": "Обновить баланс",
-        "openExplorer": "Показать в Explorer"
+        "openExplorer": "Показать в Explorer",
+        "signMessage": "Подписать сообщение"
       }
     },
     "hasPendingTransaction": "Транзакция в обработке",
@@ -684,6 +686,37 @@
       "lock": "Заблокировать",
       "txSuccess": "Транзакция успешна!",
       "txFailed": "Транзакция не удалась!"
+    }
+  },
+  "signMessageComponent": {
+    "title": "Подписать / Проверить Сообщение",
+    "tabs": {
+      "sign": "Подписать Сообщение",
+      "verify": "Проверить Сообщение"
+    },
+    "form": {
+      "sourceAccount": "Аккаунт для подписи",
+      "message": "Сообщение",
+      "messagePlaceholder": "Введите сообщение для подписи",
+      "output": "Подписанный результат (JSON)",
+      "verifyInput": "Подписанное сообщение (JSON)",
+      "verifyInputPlaceholder": "Вставьте JSON с полями identity, message и signature"
+    },
+    "buttons": {
+      "sign": "Подписать Сообщение",
+      "verify": "Проверить Подпись"
+    },
+    "result": {
+      "valid": "Подпись Действительна",
+      "invalid": "Подпись Недействительна"
+    },
+    "messages": {
+      "signError": "Не удалось подписать сообщение. Пожалуйста, попробуйте снова.",
+      "parseError": "Неверный формат JSON. Ожидается: { identity, message, signature }",
+      "invalidIdentity": "Неверный формат идентификатора. Ожидается 60 заглавных букв A-Z.",
+      "invalidSignature": "Неверный формат подписи. Ожидается 130 символов A-P.",
+      "checksumMismatch": "Проверка контрольной суммы подписи не пройдена.",
+      "accountRequired": "Пожалуйста, выберите аккаунт"
     }
   }
 }

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -11,7 +11,8 @@
       "settings": "Ayarlar",
       "ipo": "IPO",
       "assets": "Varlıklar",
-      "support": "Destek"
+      "support": "Destek",
+      "signMessage": "Mesaj İmzala"
     },
     "version": "Versiyon {{version}}",
     "version.url": "qubic.org",
@@ -260,7 +261,8 @@
         "editSeed": "Adresi Düzenle",
         "deleteSeed": "Adresi Sil",
         "refreshBalance": "Bakiyeyi Ağdan Yenile",
-        "openExplorer": "Explorer'da Görüntüle"
+        "openExplorer": "Explorer'da Görüntüle",
+        "signMessage": "Bir mesaj imzala"
       }
     },
     "hasPendingTransaction": "Bekleyen İşlemler",
@@ -689,6 +691,37 @@
       "rewardTable": "Ödül Tablosu",
       "txSuccess": "İşlem Başarılı!",
       "txFailed": "İşlem Başarısız!"
+    }
+  },
+  "signMessageComponent": {
+    "title": "Mesaj İmzala / Doğrula",
+    "tabs": {
+      "sign": "Mesaj İmzala",
+      "verify": "Mesaj Doğrula"
+    },
+    "form": {
+      "sourceAccount": "İmzalamak için hesap",
+      "message": "Mesaj",
+      "messagePlaceholder": "İmzalanacak mesajı girin",
+      "output": "İmzalı çıktı (JSON)",
+      "verifyInput": "İmzalı mesaj (JSON)",
+      "verifyInputPlaceholder": "identity, message ve signature alanlarını içeren JSON yapıştırın"
+    },
+    "buttons": {
+      "sign": "Mesajı İmzala",
+      "verify": "İmzayı Doğrula"
+    },
+    "result": {
+      "valid": "Geçerli İmza",
+      "invalid": "Geçersiz İmza"
+    },
+    "messages": {
+      "signError": "Mesaj imzalanamadı. Lütfen tekrar deneyin.",
+      "parseError": "Geçersiz JSON formatı. Beklenen: { identity, message, signature }",
+      "invalidIdentity": "Geçersiz kimlik formatı. 60 büyük harf A-Z bekleniyor.",
+      "invalidSignature": "Geçersiz imza formatı. 130 A-P karakter bekleniyor.",
+      "checksumMismatch": "İmza sağlama toplamı doğrulaması başarısız oldu.",
+      "accountRequired": "Lütfen bir hesap seçin"
     }
   }
 }

--- a/src/assets/i18n/vi.json
+++ b/src/assets/i18n/vi.json
@@ -11,7 +11,8 @@
       "settings": "Cài đặt",
       "ipo": "IPO",
       "assets": "Tài sản",
-      "support": "Hỗ trợ"
+      "support": "Hỗ trợ",
+      "signMessage": "Ký Tin Nhắn"
     },
     "version": "Phiên bản {{version}}",
     "version.url": "qubic.org",
@@ -260,7 +261,8 @@
         "editSeed": "Sửa địa chỉ",
         "deleteSeed": "Xóa địa chỉ",
         "refreshBalance": "Làm mới số dư từ mạng",
-        "openExplorer": "Xem trên Explorer"
+        "openExplorer": "Xem trên Explorer",
+        "signMessage": "Ký một tin nhắn"
       }
     },
     "hasPendingTransaction": "Giao dịch đang chờ",
@@ -688,6 +690,37 @@
       "rewardTable": "Bảng phần thưởng",
       "txSuccess": "Giao dịch thành công!",
       "txFailed": "Giao dịch thất bại!"
+    }
+  },
+  "signMessageComponent": {
+    "title": "Ký / Xác Minh Tin Nhắn",
+    "tabs": {
+      "sign": "Ký Tin Nhắn",
+      "verify": "Xác Minh Tin Nhắn"
+    },
+    "form": {
+      "sourceAccount": "Tài khoản để ký",
+      "message": "Tin nhắn",
+      "messagePlaceholder": "Nhập tin nhắn để ký",
+      "output": "Kết quả đã ký (JSON)",
+      "verifyInput": "Tin nhắn đã ký (JSON)",
+      "verifyInputPlaceholder": "Dán JSON với các trường identity, message và signature"
+    },
+    "buttons": {
+      "sign": "Ký Tin Nhắn",
+      "verify": "Xác Minh Chữ Ký"
+    },
+    "result": {
+      "valid": "Chữ Ký Hợp Lệ",
+      "invalid": "Chữ Ký Không Hợp Lệ"
+    },
+    "messages": {
+      "signError": "Không thể ký tin nhắn. Vui lòng thử lại.",
+      "parseError": "Định dạng JSON không hợp lệ. Mong đợi: { identity, message, signature }",
+      "invalidIdentity": "Định dạng danh tính không hợp lệ. Mong đợi 60 ký tự in hoa A-Z.",
+      "invalidSignature": "Định dạng chữ ký không hợp lệ. Mong đợi 130 ký tự A-P.",
+      "checksumMismatch": "Xác minh tổng kiểm tra chữ ký thất bại.",
+      "accountRequired": "Vui lòng chọn một tài khoản"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds a new **Sign / Verify Message** page compatible with the [Qubic.NET.Wallet](https://github.com/qubic/Qubic.NET.Wallet) format
- Signs raw UTF-8 bytes with SchnorrQ (no pre-hashing), encodes signature in shifted hex (A-P chars) with K12 checksum
- New `/sign-message` route with two tabs: Sign Message and Verify Message
- "Sign Message" menu item added to sidenav navigation and account card actions
- Identity checksum validated cryptographically via `verifyIdentity()`
- Translations added for all 11 locales