### PR TITLE
fix: support plural TransferSharesManagementRights identifier

### DIFF
--- a/src/app/assets/transfer-rights/transfer-rights.component.ts
+++ b/src/app/assets/transfer-rights/transfer-rights.component.ts
@@ -460,7 +460,7 @@ export class TransferRightsComponent implements OnInit, OnDestroy {
    * Handle source contract selection change
    * Filters destination contracts based on the source contract's procedure type:
    * - RevokeAssetManagementRights: destination is only QX
-   * - TransferShareManagementRights: destination is contracts with allowTransferShares AND TransferShareManagementRights
+   * - TransferShare(s)ManagementRights: destination is contracts with allowTransferShares AND a transfer rights procedure
    */
   private onSourceContractChange(sourceContract: SourceContractOption | null): void {
     this.selectedSourceContract = sourceContract;

--- a/src/app/constants/qubic.constants.ts
+++ b/src/app/constants/qubic.constants.ts
@@ -24,14 +24,20 @@ export const MAX_WALLET_ACCOUNTS = 15;
 export const ASSET_TRANSFER_FEE = QubicDefinitions.QX_TRANSFER_ASSET_FEE;
 
 /**
- * Source identifier for Transfer Share Management Rights procedure
- * Used to match procedures by sourceIdentifier field (case insensitive)
+ * Source identifiers for Transfer Share Management Rights procedure.
+ * Both singular ('TransferShareManagementRights') and plural ('TransferSharesManagementRights')
+ * forms exist across different contract versions. Matched case-insensitively.
  */
-export const TRANSFER_SHARE_MANAGEMENT_RIGHTS_IDENTIFIER = 'TransferShareManagementRights';
+export const TRANSFER_RIGHTS_IDENTIFIERS = [
+  'TransferShareManagementRights',
+  'TransferSharesManagementRights',
+] as const;
 
 /**
- * Source identifier for Revoke Asset Management Rights procedure
- * Used to match procedures by sourceIdentifier field (case insensitive)
+ * Source identifiers for Revoke Asset Management Rights procedure.
+ * Matched case-insensitively.
  */
-export const REVOKE_ASSET_MANAGEMENT_RIGHTS_IDENTIFIER = 'RevokeAssetManagementRights';
+export const REVOKE_RIGHTS_IDENTIFIERS = [
+  'RevokeAssetManagementRights',
+] as const;
 

--- a/src/app/utils/smart-contract.utils.ts
+++ b/src/app/utils/smart-contract.utils.ts
@@ -1,25 +1,30 @@
 import { SmartContractProcedure, StaticSmartContract } from '../services/apis/static/qubic-static.model';
 import {
-  TRANSFER_SHARE_MANAGEMENT_RIGHTS_IDENTIFIER,
-  REVOKE_ASSET_MANAGEMENT_RIGHTS_IDENTIFIER,
+  TRANSFER_RIGHTS_IDENTIFIERS,
+  REVOKE_RIGHTS_IDENTIFIERS,
 } from '../constants/qubic.constants';
 
 /**
- * Find a procedure that has a TransferShareManagementRights sourceIdentifier.
+ * Match a procedure's sourceIdentifier against a list of known identifiers (case-insensitive).
  */
-export function findTransferRightsProcedure(contract: StaticSmartContract): SmartContractProcedure | null {
-  return contract.procedures?.find(p =>
-    p.sourceIdentifier?.toLowerCase() === TRANSFER_SHARE_MANAGEMENT_RIGHTS_IDENTIFIER.toLowerCase()
-  ) ?? null;
+function matchesIdentifier(sourceIdentifier: string | undefined, identifiers: readonly string[]): boolean {
+  if (!sourceIdentifier) return false;
+  const id = sourceIdentifier.toLowerCase();
+  return identifiers.some(known => known.toLowerCase() === id);
 }
 
 /**
- * Find a procedure that has a RevokeAssetManagementRights sourceIdentifier.
+ * Find a procedure that matches any known Transfer Share Management Rights identifier.
+ */
+export function findTransferRightsProcedure(contract: StaticSmartContract): SmartContractProcedure | null {
+  return contract.procedures?.find(p => matchesIdentifier(p.sourceIdentifier, TRANSFER_RIGHTS_IDENTIFIERS)) ?? null;
+}
+
+/**
+ * Find a procedure that matches any known Revoke Asset Management Rights identifier.
  */
 export function findRevokeRightsProcedure(contract: StaticSmartContract): SmartContractProcedure | null {
-  return contract.procedures?.find(p =>
-    p.sourceIdentifier?.toLowerCase() === REVOKE_ASSET_MANAGEMENT_RIGHTS_IDENTIFIER.toLowerCase()
-  ) ?? null;
+  return contract.procedures?.find(p => matchesIdentifier(p.sourceIdentifier, REVOKE_RIGHTS_IDENTIFIERS)) ?? null;
 }
 
 /**
@@ -39,7 +44,8 @@ export function findManagementRightsProcedure(contract: StaticSmartContract): { 
 }
 
 /**
- * Check if a smart contract has a management rights procedure (TransferShareManagementRights or RevokeAssetManagementRights).
+ * Check if a smart contract has any management rights procedure
+ * (TransferShare(s)ManagementRights or RevokeAssetManagementRights).
  */
 export function hasManagementRightsProcedure(contract: StaticSmartContract): boolean {
   return !!findManagementRightsProcedure(contract);


### PR DESCRIPTION
Refactor identifier constants from individual strings to arrays to support both singular and plural forms of the transfer rights procedure identifier across different contract versions.

- Replace separate constants with TRANSFER_RIGHTS_IDENTIFIERS and REVOKE_RIGHTS_IDENTIFIERS arrays
- Extract shared matchesIdentifier helper for case-insensitive matching
- Update JSDoc comments to reflect both identifier variants