### PR TITLE
fix: constrain asset card width and truncate long names

### DIFF
--- a/src/app/assets/assets.component.scss
+++ b/src/app/assets/assets.component.scss
@@ -71,7 +71,8 @@
 }
 
 mat-card {
-  min-width: 385px; 
+  width: 100%;
+  max-width: 420px;
   margin-bottom: 20px;
 }
 
@@ -85,6 +86,13 @@ mat-card {
   }
 }
 
+
+.dashboard-wallet-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
 
 .dashboard-balance-name {
   font-weight: bold;


### PR DESCRIPTION
Match dashboard card styling: set max-width 420px on cards and add text-overflow ellipsis on wallet name to prevent cards from expanding with long account names.