### PR TITLE
refactor(balance): align transaction-type label with explorer

### DIFF
--- a/src/app/balance/balance.component.html
+++ b/src/app/balance/balance.component.html
@@ -164,7 +164,7 @@
                                         </div>
                                         <div class="col-value disable-area">
                                             <span class="value">
-                                                {{ formatInputType(transaction.inputType,transaction.destId) }}</span>
+                                                {{ formatInputType(transaction.inputType, transaction.destId, transaction.tickNumber) }}</span>
                                         </div>
                                     </div>
                                     <!-- Add Fee row after Type row for asset transfers -->
@@ -363,7 +363,8 @@
                                     <div class="col-value disable-area">
                                         <span class="value">
                                             {{ formatInputType(transaction.transactions[0].transaction.inputType,
-                                            transaction.transactions[0].transaction.destId) }}
+                                            transaction.transactions[0].transaction.destId,
+                                            transaction.transactions[0].transaction.tickNumber) }}
                                         </span>
                                     </div>
                                 </div>

--- a/src/app/balance/balance.component.ts
+++ b/src/app/balance/balance.component.ts
@@ -13,12 +13,14 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { QubicTransferAssetPayload } from '@qubic-lib/qubic-ts-library/dist/qubic-types/transacion-payloads/QubicTransferAssetPayload'
 import { QubicTransferSendManyPayload } from '@qubic-lib/qubic-ts-library/dist/qubic-types/transacion-payloads/QubicTransferSendManyPayload'
-import { shortenAddress, getDisplayName, getShortDisplayName, getCompactDisplayName, EMPTY_QUBIC_ADDRESS } from '../utils/address.utils';
+import { shortenAddress, getDisplayName, getShortDisplayName, getCompactDisplayName } from '../utils/address.utils';
 import { QubicDefinitions } from '@qubic-lib/qubic-ts-library/dist/QubicDefinitions';
 import { AddressNameService } from '../services/address-name.service';
+import { QubicStaticService } from '../services/apis/static/qubic-static.service';
 import { ExplorerUrlHelper } from '../services/explorer-url.helper';
 import { isSendManyTransaction, isSimpleTransfer } from '../helpers/transaction-status.helper';
 import { PendingTransactionService } from '../services/pending-transaction.service';
+import { getTransactionTypeDisplayLong } from '../utils/transaction-type.utils';
 
 @Component({
   selector: 'app-balance',
@@ -48,6 +50,7 @@ export class BalanceComponent implements OnInit, OnDestroy {
   selectedElement = new FormControl('element1');
 
   public processedTickIntervals: ProcessedTickInterval[] = [];
+  private sortedTickRanges: { epoch: number; minFirstTick: number; maxLastTick: number }[] = [];
   public currentSelectedEpoch = 0;
   public viewStartTick: number = 0;
   public viewEndTick: number = 0;
@@ -65,7 +68,8 @@ export class BalanceComponent implements OnInit, OnDestroy {
     private _snackBar: MatSnackBar,
     public us: UpdaterService,
     private addressNameService: AddressNameService,
-    private pendingTxService: PendingTransactionService
+    private pendingTxService: PendingTransactionService,
+    private qubicStatic: QubicStaticService
   ) {
     this.seedFilterFormControl.setValue(null);
   }
@@ -117,6 +121,7 @@ export class BalanceComponent implements OnInit, OnDestroy {
       .subscribe(intervals => {
         if (intervals && intervals.length > 0) {
           this.processedTickIntervals = intervals;
+          this.rebuildSortedTickRanges();
           this.currentSelectedEpoch = intervals[intervals.length - 1].epoch;
           // Just initialize the tick range, don't fetch transactions yet
           // Transactions will be fetched when user switches to "By Epochs" tab
@@ -630,27 +635,49 @@ export class BalanceComponent implements OnInit, OnDestroy {
     }
   }
 
-  formatInputType(inputType: number, destination: string): string {
-    // Check if it's a smart contract transaction (inputType > 0 and not protocol message)
-    const isSmartContract = inputType > 0 && destination !== EMPTY_QUBIC_ADDRESS;
-
-    // Base type
-    const baseType = inputType.toString();
-    const category = isSmartContract ? 'SC' : 'Standard';
-
-    // Try to get smart contract details and procedure name
-    if (isSmartContract) {
-      const smartContract = this.addressNameService.getSmartContractByAddressSync(destination);
-      if (smartContract && smartContract.procedures) {
-        const procedure = smartContract.procedures.find((p: any) => p.id === inputType);
-        if (procedure) {
-          return `${baseType} ${category} (${procedure.name})`;
-        }
-      }
+  private rebuildSortedTickRanges(): void {
+    const ranges = new Map<number, { epoch: number; minFirstTick: number; maxLastTick: number }>();
+    for (const interval of this.processedTickIntervals) {
+      const existing = ranges.get(interval.epoch);
+      ranges.set(interval.epoch, existing
+        ? {
+            epoch: interval.epoch,
+            minFirstTick: Math.min(existing.minFirstTick, interval.firstTick),
+            maxLastTick: Math.max(existing.maxLastTick, interval.lastTick),
+          }
+        : { epoch: interval.epoch, minFirstTick: interval.firstTick, maxLastTick: interval.lastTick }
+      );
     }
+    this.sortedTickRanges = Array.from(ranges.values()).sort((a, b) => a.epoch - b.epoch);
+  }
 
-    // Return without procedure name
-    return `${baseType} ${category}`;
+  private getEpochForTick(tickNumber: number): number | undefined {
+    const sorted = this.sortedTickRanges;
+
+    const match = sorted.find(
+      (r) => tickNumber >= r.minFirstTick && tickNumber <= r.maxLastTick
+    );
+    if (match) return match.epoch;
+
+    const gap = sorted.find(
+      (r, i) => i < sorted.length - 1 && tickNumber > r.maxLastTick && tickNumber < sorted[i + 1].minFirstTick
+    );
+    if (gap) return gap.epoch;
+
+    const last = sorted[sorted.length - 1];
+    if (last && tickNumber > last.maxLastTick) return last.epoch;
+
+    return undefined;
+  }
+
+  formatInputType(inputType: number, destination: string, tickNumber: number): string {
+    return getTransactionTypeDisplayLong(
+      destination,
+      inputType,
+      this.qubicStatic.cachedSmartContracts,
+      this.qubicStatic.cachedTransactionInputTypes,
+      this.getEpochForTick(tickNumber)
+    );
   }
 
   ngOnDestroy(): void {

--- a/src/app/services/apis/static/qubic-static.model.ts
+++ b/src/app/services/apis/static/qubic-static.model.ts
@@ -20,6 +20,7 @@ export interface StaticSmartContract {
   procedures: SmartContractProcedure[];
   website?: string;
   allowTransferShares?: boolean;
+  sharesAuctionEpoch?: number;
 }
 
 export interface GetSmartContractsResponse {
@@ -51,6 +52,15 @@ export interface Token {
 
 export interface GetTokensResponse {
   tokens: Token[];
+}
+
+export interface TransactionInputType {
+  id: number;
+  label: string;
+}
+
+export interface GetProtocolResponse {
+  transaction_input_types: TransactionInputType[];
 }
 
 /**

--- a/src/app/services/apis/static/qubic-static.service.ts
+++ b/src/app/services/apis/static/qubic-static.service.ts
@@ -10,7 +10,9 @@ import {
   AddressLabel,
   GetAddressLabelsResponse,
   Token,
-  GetTokensResponse
+  GetTokensResponse,
+  TransactionInputType,
+  GetProtocolResponse
 } from './qubic-static.model';
 import { environment } from '../../../../environments/environment';
 
@@ -38,18 +40,21 @@ export class QubicStaticService {
   public exchanges$: BehaviorSubject<Exchange[] | null> = new BehaviorSubject<Exchange[] | null>(null);
   public addressLabels$: BehaviorSubject<AddressLabel[] | null> = new BehaviorSubject<AddressLabel[] | null>(null);
   public tokens$: BehaviorSubject<Token[] | null> = new BehaviorSubject<Token[] | null>(null);
+  public transactionInputTypes$: BehaviorSubject<TransactionInputType[] | null> = new BehaviorSubject<TransactionInputType[] | null>(null);
 
   // Cache timestamps
   private smartContractsLastFetch: number = 0;
   private exchangesLastFetch: number = 0;
   private addressLabelsLastFetch: number = 0;
   private tokensLastFetch: number = 0;
+  private transactionInputTypesLastFetch: number = 0;
 
   // Observable cache for deduplication
   private smartContractsCache$?: Observable<StaticSmartContract[]>;
   private exchangesCache$?: Observable<Exchange[]>;
   private addressLabelsCache$?: Observable<AddressLabel[]>;
   private tokensCache$?: Observable<Token[]>;
+  private transactionInputTypesCache$?: Observable<TransactionInputType[]>;
 
   constructor(private http: HttpClient) {
     // Initialize data fetching
@@ -64,6 +69,7 @@ export class QubicStaticService {
     this.getExchanges().subscribe();
     this.getAddressLabels().subscribe();
     this.getTokens().subscribe();
+    this.getTransactionInputTypes().subscribe();
   }
 
   /**
@@ -186,6 +192,35 @@ export class QubicStaticService {
   }
 
   /**
+   * Get protocol transaction input types with caching
+   */
+  public getTransactionInputTypes(): Observable<TransactionInputType[]> {
+    const now = Date.now();
+
+    if (this.transactionInputTypesCache$ && (now - this.transactionInputTypesLastFetch) < this.CACHE_DURATION_MS) {
+      return this.transactionInputTypesCache$;
+    }
+
+    this.transactionInputTypesCache$ = this.http
+      .get<GetProtocolResponse>(`${this.BASE_URL}/protocol.json`)
+      .pipe(
+        retry({ count: 3, delay: 1000 }),
+        map(response => response.transaction_input_types),
+        tap(data => {
+          this.transactionInputTypes$.next(data);
+          this.transactionInputTypesLastFetch = now;
+        }),
+        catchError(error => {
+          console.error('Error fetching transaction input types:', error);
+          return of(this.transactionInputTypes$.value || []);
+        }),
+        shareReplay(1)
+      );
+
+    return this.transactionInputTypesCache$;
+  }
+
+  /**
    * Force refresh all data by clearing cache
    */
   public refreshAllData(): void {
@@ -193,11 +228,13 @@ export class QubicStaticService {
     this.exchangesLastFetch = 0;
     this.addressLabelsLastFetch = 0;
     this.tokensLastFetch = 0;
+    this.transactionInputTypesLastFetch = 0;
 
     this.smartContractsCache$ = undefined;
     this.exchangesCache$ = undefined;
     this.addressLabelsCache$ = undefined;
     this.tokensCache$ = undefined;
+    this.transactionInputTypesCache$ = undefined;
 
     this.fetchAllData();
   }
@@ -219,5 +256,9 @@ export class QubicStaticService {
 
   public get cachedTokens(): Token[] | null {
     return this.tokens$.value;
+  }
+
+  public get cachedTransactionInputTypes(): TransactionInputType[] | null {
+    return this.transactionInputTypes$.value;
   }
 }

--- a/src/app/utils/transaction-type.utils.ts
+++ b/src/app/utils/transaction-type.utils.ts
@@ -1,0 +1,65 @@
+import { QubicDefinitions } from '@qubic-lib/qubic-ts-library/dist/QubicDefinitions';
+import { StaticSmartContract, TransactionInputType } from '../services/apis/static/qubic-static.model';
+
+export const PLACE_BID_LABEL = 'Place Bid';
+
+const isProtocolMessage = (address: string): boolean =>
+  address === QubicDefinitions.ARBITRATOR || address === QubicDefinitions.EMPTY_ADDRESS;
+
+export const isSmartContractTx = (destination: string, inputType: number): boolean =>
+  !isProtocolMessage(destination) && inputType > 0;
+
+export const getProcedureName = (
+  contractAddress: string,
+  inputType: number,
+  smartContracts?: StaticSmartContract[] | null
+): string | undefined => {
+  if (!smartContracts) return undefined;
+  const contract = smartContracts.find((sc) => sc.address === contractAddress);
+  return contract?.procedures.find((proc) => proc.id === inputType)?.name;
+};
+
+export const getInputTypeLabel = (
+  inputType: number,
+  transactionInputTypes?: TransactionInputType[] | null
+): string | undefined => {
+  if (!transactionInputTypes) return undefined;
+  return transactionInputTypes.find((t) => t.id === inputType)?.label;
+};
+
+export const getSharesAuctionBidContract = (
+  destination: string,
+  inputType: number,
+  epoch?: number,
+  smartContracts?: StaticSmartContract[] | null
+): StaticSmartContract | undefined => {
+  if (inputType !== 1 || epoch == null || !smartContracts) return undefined;
+  const contract = smartContracts.find((sc) => sc.address === destination);
+  return contract && epoch === contract.sharesAuctionEpoch ? contract : undefined;
+};
+
+export const getTransactionTypeDisplay = (
+  destination: string,
+  inputType: number,
+  smartContracts?: StaticSmartContract[] | null,
+  protocolData?: TransactionInputType[] | null,
+  epoch?: number
+): string => {
+  if (getSharesAuctionBidContract(destination, inputType, epoch, smartContracts)) {
+    return PLACE_BID_LABEL;
+  }
+  if (isSmartContractTx(destination, inputType)) {
+    return getProcedureName(destination, inputType, smartContracts) || 'SC';
+  }
+  return getInputTypeLabel(inputType, protocolData) || 'Standard';
+};
+
+export const getTransactionTypeDisplayLong = (
+  destination: string,
+  inputType: number,
+  smartContracts?: StaticSmartContract[] | null,
+  protocolData?: TransactionInputType[] | null,
+  epoch?: number
+): string => {
+  return `${getTransactionTypeDisplay(destination, inputType, smartContracts, protocolData, epoch)} (${inputType})`;
+};


### PR DESCRIPTION
Port the explorer's getTransactionTypeDisplayLong helper into src/app/utils/transaction-type.utils.ts and use it to format the "Type" cell in the balance table. Display now reads "<label> (N)" instead of "N Standard|SC (<proc>)" and supports the "Place Bid" label for shares-auction bids and protocol input-type labels.

Extends QubicStaticService to fetch /v1/general/data/protocol.json for the transaction-input-type labels and adds sharesAuctionEpoch to StaticSmartContract.

Adds a per-epoch tick range cache on BalanceComponent so the tick->epoch lookup driving each row doesn't rebuild a Map and sort on every change-detection cycle.