### PR TITLE
fix: scope mat-card 420px cap to .card-list grid tiles

### DIFF
--- a/src/app/assets/assets.component.scss
+++ b/src/app/assets/assets.component.scss
@@ -11,7 +11,9 @@
   flex-wrap: wrap;
   margin: 20px 0;
   overflow-x: auto;
+  width: 100%;
   min-width: 120px;
+  max-width: 420px;
 
   .row {
     display: flex;
@@ -70,7 +72,7 @@
 
 }
 
-mat-card {
+.card-list mat-card {
   width: 100%;
   max-width: 420px;
   margin-bottom: 20px;


### PR DESCRIPTION
The previous unscoped `mat-card { max-width: 420px }` rule in assets.component.scss matched every mat-card in the component template, including the Send Assets form — capping it at 420px regardless of screen width. Scope it to `.card-list mat-card` so only the asset tiles are constrained, and add explicit width caps on `.asset-card` to preserve the no-assets card's prior size.