### PR TITLE
fix(ipo): exclude watch-only seeds from place-bid source dropdown

### DIFF
--- a/src/app/ipo/place-bid/place-bid.component.ts
+++ b/src/app/ipo/place-bid/place-bid.component.ts
@@ -107,7 +107,7 @@ export class PlaceBidComponent implements OnInit, OnDestroy {
   }
 
   getSeeds() {
-    return this.walletService.getSeeds();
+    return this.walletService.getSeeds().filter(s => !s.isOnlyWatch);
   }
 
   getSelectedSourceSeed() {


### PR DESCRIPTION
The source-account dropdown in the place-bid form was populated from the unfiltered seed list, so read-only (watch-only) addresses appeared as selectable sources even though they cannot sign transactions. Filter them out, matching the pattern already used in payment, transfer-rights, sign-message, qearn/staking, and assets.